### PR TITLE
/ へのアクセスでタスク一覧を表示するように

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  root :to => 'tasks#index'
 end


### PR DESCRIPTION
https://github.com/mrtc0/todo/issues/5 のルーティングに関する変更です。

`/` へアクセスしたときにタスク一覧を表示する `tasks#index` を表示するようにしました。