### PR TITLE
i18n化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,8 @@ gem 'jbuilder', '~> 2.5'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 
+gem 'http_accept_language'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,7 @@ GEM
     ffi (1.9.25)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
+    http_accept_language (2.1.1)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
     io-like (0.3.0)
@@ -256,6 +257,7 @@ DEPENDENCIES
   capybara (>= 2.15, < 4.0)
   chromedriver-helper
   coffee-rails (~> 4.2)
+  http_accept_language
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   pg

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::Base
+  before_action :set_locale
+
+  private
+
+    def set_locale
+      I18n.locale = http_accept_language.compatible_language_from(I18n.available_locales)
+    end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -15,7 +15,7 @@ class TasksController < ApplicationController
 
     respond_to do |format|
       if @task.save
-        format.html { redirect_to @task, flash: { success: 'タスクを作成しました' } }
+        format.html { redirect_to @task, flash: { success: t('view.task.message.created') } }
       else
         # TODO: エラー処理を書く
         format.html { render :new }
@@ -32,7 +32,7 @@ class TasksController < ApplicationController
   def update
     respond_to do |format|
       if @task.update(task_params)
-        format.html { redirect_to @task, flash: { success: '更新しました' } }
+        format.html { redirect_to @task, flash: { success: t('view.task.message.updated') } }
       else
         # TODO: エラー処理を書く
         format.html { render :edit }
@@ -44,7 +44,7 @@ class TasksController < ApplicationController
     @task.destroy
 
     respond_to do |format|
-      format.html { redirect_to tasks_url, flash: { success: 'タスクを削除しました' } }
+      format.html { redirect_to tasks_url, flash: { success: t('view.task.message.deleted') } }
     end
   end
 

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -3,10 +3,10 @@
   <li>
     <p>
       <%= task.title %>
-      <%= link_to "編集", edit_task_path(task) %>  
-      <%= link_to "削除", task_path(task), method: :delete, data: {confirm: "本当に削除しますか？"} %>
+      <%= link_to t('view.common.link_text.edit'), edit_task_path(task) %>
+      <%= link_to t('view.common.link_text.delete'), task_path(task), method: :delete, data: {confirm: t('view.task.message.delete_confirm')} %>
     </p>
   </li>
 <% end %>
 </ul>
-<%= link_to "新規作成", new_task_path %>
+<%= link_to t('view.common.link_text.new'), new_task_path %>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,4 +1,4 @@
-<h1>タスクの新規作成</h1>
+<h1><%= t('view.task.title.new') %></h1>
 
 <%= render 'form', task: @task %>
-<%= link_to '戻る', tasks_path %>
+<%= link_to t('view.common.link_text.back'), tasks_path %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -5,5 +5,5 @@
 <p>Priority: <%= @task.priority %></p>
 <p>Expire_at: <%= @task.expire_at %></p>
 
-<p><%= link_to "編集する", edit_task_path(@task) %></p>
-<p><%= link_to "削除", task_path(@task), method: :delete, data: {confirm: "本当に削除しますか？"} %></p>
+<p><%= link_to t('view.common.link_text.edit'), edit_task_path(@task) %></p>
+<p><%= link_to t('view.common.link_text.delete'), task_path(@task), method: :delete, data: {confirm: t('view.task.message.delete_confirm')} %></p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,7 @@ module Todo
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+    config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,33 +1,232 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   'true': 'foo'
-#
-# To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
-
+---
 en:
-  hello: "Hello world"
+  view:
+    task:
+      message:
+        created: "Created a new task"
+        updated: "Updated a task"
+        deleted: "Deleted a task"
+        delete_confirm: "Are you sure you want to delte the task?"
+      title:
+        new: "Create new task"
+    common:
+      button_text:
+        create: "Create"
+        update: "Update"
+        delete: "Delete"
+      link_text:
+        new: "New"
+        edit: "Edit"
+        delete: "Delte"
+        back: "Back"
+  activerecord:
+    errors:
+      messages:
+        record_invalid: "Validation failed: %{errors}"
+        restrict_dependent_destroy:
+          has_one: "Cannot delete record because a dependent %{record} exists"
+          has_many: "Cannot delete record because dependent %{record} exist"
+  date:
+    abbr_day_names:
+    - Sun
+    - Mon
+    - Tue
+    - Wed
+    - Thu
+    - Fri
+    - Sat
+    abbr_month_names:
+    -
+    - Jan
+    - Feb
+    - Mar
+    - Apr
+    - May
+    - Jun
+    - Jul
+    - Aug
+    - Sep
+    - Oct
+    - Nov
+    - Dec
+    day_names:
+    - Sunday
+    - Monday
+    - Tuesday
+    - Wednesday
+    - Thursday
+    - Friday
+    - Saturday
+    formats:
+      default: "%Y-%m-%d"
+      long: "%B %d, %Y"
+      short: "%b %d"
+    month_names:
+    -
+    - January
+    - February
+    - March
+    - April
+    - May
+    - June
+    - July
+    - August
+    - September
+    - October
+    - November
+    - December
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: about 1 hour
+        other: about %{count} hours
+      about_x_months:
+        one: about 1 month
+        other: about %{count} months
+      about_x_years:
+        one: about 1 year
+        other: about %{count} years
+      almost_x_years:
+        one: almost 1 year
+        other: almost %{count} years
+      half_a_minute: half a minute
+      less_than_x_minutes:
+        one: less than a minute
+        other: less than %{count} minutes
+      less_than_x_seconds:
+        one: less than 1 second
+        other: less than %{count} seconds
+      over_x_years:
+        one: over 1 year
+        other: over %{count} years
+      x_days:
+        one: 1 day
+        other: "%{count} days"
+      x_minutes:
+        one: 1 minute
+        other: "%{count} minutes"
+      x_months:
+        one: 1 month
+        other: "%{count} months"
+      x_years:
+        one: 1 year
+        other: "%{count} years"
+      x_seconds:
+        one: 1 second
+        other: "%{count} seconds"
+    prompts:
+      day: Day
+      hour: Hour
+      minute: Minute
+      month: Month
+      second: Seconds
+      year: Year
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: must be accepted
+      blank: can't be blank
+      present: must be blank
+      confirmation: doesn't match %{attribute}
+      empty: can't be empty
+      equal_to: must be equal to %{count}
+      even: must be even
+      exclusion: is reserved
+      greater_than: must be greater than %{count}
+      greater_than_or_equal_to: must be greater than or equal to %{count}
+      inclusion: is not included in the list
+      invalid: is invalid
+      less_than: must be less than %{count}
+      less_than_or_equal_to: must be less than or equal to %{count}
+      model_invalid: "Validation failed: %{errors}"
+      not_a_number: is not a number
+      not_an_integer: must be an integer
+      odd: must be odd
+      required: must exist
+      taken: has already been taken
+      too_long:
+        one: is too long (maximum is 1 character)
+        other: is too long (maximum is %{count} characters)
+      too_short:
+        one: is too short (minimum is 1 character)
+        other: is too short (minimum is %{count} characters)
+      wrong_length:
+        one: is the wrong length (should be 1 character)
+        other: is the wrong length (should be %{count} characters)
+      other_than: must be other than %{count}
+    template:
+      body: 'There were problems with the following fields:'
+      header:
+        one: 1 error prohibited this %{model} from being saved
+        other: "%{count} errors prohibited this %{model} from being saved"
+  helpers:
+    select:
+      prompt: Please select
+    submit:
+      create: Create %{model}
+      submit: Save %{model}
+      update: Update %{model}
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "$"
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Billion
+          million: Million
+          quadrillion: Quadrillion
+          thousand: Thousand
+          trillion: Trillion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: ", and "
+      two_words_connector: " and "
+      words_connector: ", "
+  time:
+    am: am
+    formats:
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%B %d, %Y %H:%M"
+      short: "%d %b %H:%M"
+    pm: pm

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,224 @@
+---
+ja:
+  view:
+    task:
+      message:
+        created: "タスクを作成しました"
+        updated: "タスクを更新しました"
+        deleted: "タスクを削除しました"
+        delete_confirm: "本当に削除しますか？"
+      title:
+        new: "タスクの新規作成"
+    common:
+      button_text:
+        create: "作成する"
+        update: "更新する"
+        delete: "削除する"
+      link_text:
+        new: "新規作成"
+        edit: "編集"
+        delete: "削除"
+        back: "戻る"
+  activerecord:
+    errors:
+      messages:
+        record_invalid: "バリデーションに失敗しました: %{errors}"
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+  date:
+    abbr_day_names:
+    - 日
+    - 月
+    - 火
+    - 水
+    - 木
+    - 金
+    - 土
+    abbr_month_names:
+    -
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 日曜日
+    - 月曜日
+    - 火曜日
+    - 水曜日
+    - 木曜日
+    - 金曜日
+    - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+    -
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 約1時間
+        other: 約%{count}時間
+      about_x_months:
+        one: 約1ヶ月
+        other: 約%{count}ヶ月
+      about_x_years:
+        one: 約1年
+        other: 約%{count}年
+      almost_x_years:
+        one: 1年弱
+        other: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_minutes:
+        one: 1分以内
+        other: "%{count}分未満"
+      less_than_x_seconds:
+        one: 1秒以内
+        other: "%{count}秒未満"
+      over_x_years:
+        one: 1年以上
+        other: "%{count}年以上"
+      x_days:
+        one: 1日
+        other: "%{count}日"
+      x_minutes:
+        one: 1分
+        other: "%{count}分"
+      x_months:
+        one: 1ヶ月
+        other: "%{count}ヶ月"
+      x_years:
+        one: 1年
+        other: "%{count}年"
+      x_seconds:
+        one: 1秒
+        other: "%{count}秒"
+    prompts:
+      day: 日
+      hour: 時
+      minute: 分
+      month: 月
+      second: 秒
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      present: は入力しないでください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: "バリデーションに失敗しました: %{errors}"
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+      other_than: は%{count}以外の値にしてください
+    template:
+      body: 次の項目を確認してください
+      header:
+        one: "%{model}にエラーが発生しました"
+        other: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: 、
+      two_words_connector: 、
+      words_connector: 、
+  time:
+    am: 午前
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"
+    pm: 午後

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -15,7 +15,7 @@ describe 'Task' do
     fill_in 'Expire at', with: '2019-01-01 00:00:00'
     fill_in 'Priority', with: '1'
     find(:xpath, '/html[1]/body[1]/form[1]/div[@class="actions"]/input[1]').click
-    expect(page).to have_content 'タスクを作成しました'
+    expect(page).to have_content I18n.t('view.task.message.created')
     expect(Task.exists?(title: 'タスク1')).to be_truthy
   end
 
@@ -24,13 +24,13 @@ describe 'Task' do
 
     fill_in 'Title', with: 'タスク-edited'
     find(:xpath, '/html[1]/body[1]/form[1]/div[@class="actions"]/input[1]').click
-    expect(page).to have_content '更新しました'
+    expect(page).to have_content I18n.t('view.task.message.updated')
     expect(Task.exists?(title: 'タスク-edited')).to eq(true)
   end
 
   example 'タスクの削除ができて、メッセージが表示されること' do
     visit '/tasks/'
     expect { click_link '削除' }.to change(Task, :count).by(-1)
-    expect(page).to have_content 'タスクを削除しました'
+    expect(page).to have_content I18n.t('view.task.message.deleted')
   end
 end


### PR DESCRIPTION
### 概要

HTTPリクエストヘッダのAccept-Languageに基づいて、表示を英語・日本語と切り替えるようにしました。

ref: https://github.com/everyleaf/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%979-%E3%82%A2%E3%83%97%E3%83%AA%E3%81%AE%E6%97%A5%E6%9C%AC%E8%AA%9E%E9%83%A8%E5%88%86%E3%82%92%E5%85%B1%E9%80%9A%E5%8C%96%E3%81%97%E3%82%88%E3%81%86

### 詳細

- http_accept_language というgemを導入し、ApplicationControllerでAccept-Languageから言語を特定するようにしました
  - https://github.com/mrtc0/todo/commit/64bf083c62438c2604795b51dba5a1d36cc6eec7
- 日本語と英語のそれぞれの定義ファイルを用意しました
  - https://github.com/mrtc0/todo/commit/8777a3be0190ea8a752aacc834f433fdac5f254a
- ViewとControllerでそれぞれi18nを通して表示するように変更しました

### レビューしてほしいところ

- 定義ファイルの書き方はOKか
  - 共通して使いそうなものは `common` などに分類した
  - 今後アプリケーションが大きくなるにつれて、この方針で問題ないか
- 普通にi18n化が文言の定義を追加していくだけの作業で面倒くさいんですが、このやり方であっているのか...