### PR TITLE
タイムゾーンをTokyoに

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,6 @@ module Todo
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+    config.time_zone = 'Tokyo'
   end
 end


### PR DESCRIPTION
### このPRで解決すること

Railsのタイムゾーンを日本時間に変更しました。

```ruby
[1] pry(main)> Time.zone
=> #<ActiveSupport::TimeZone:0x00007fd53deb82b8
@name="Tokyo",
@tzinfo=#<TZInfo::DataTimezone: Asia/Tokyo>,
@utc_offset=nil>
```

ref : https://github.com/everyleaf/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9710-rails%E3%81%AE%E3%82%BF%E3%82%A4%E3%83%A0%E3%82%BE%E3%83%BC%E3%83%B3%E3%82%92%E8%A8%AD%E5%AE%9A%E3%81%97%E3%82%88%E3%81%86

### レビュアー

どなたでも
