### PR TITLE
CircleCIとDockerで動作させるためにデータベースの設定を変更

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -2,9 +2,9 @@ default: &default
   adapter: postgresql
   encoding: utf8
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  username: <%= ENV['DATABASE_USER'] %>
+  username: <%= ENV['DATABASE_USER'] || ENV['POSTGRES_USER'] %>
   password: <%= ENV['DATABASE_PASSWORD'] %>
-  host: <%= ENV.fetch('DATABASE_HOST') %>
+  host: <%= ENV.fetch('DATABASE_HOST', '127.0.0.1') %>
   timeout: 5000
 
 development:


### PR DESCRIPTION
### 概要

DockerizeしてDB周りの設定がうまくいかないようになっていた。
具体的には Docker では `DATABASE_USER` だが、 CircleCIでは `POSTGRES_USER` を使用している。  
 
なのでそれぞれ env を取得して、なければ別の設定を...という感じに。

`ENV['DATABASE_USER'] || ENV['POSTGRES_USER']` は `fetch` で書こうと思ったけど、`ENV.fetch` の中にまた `ENV` が出てくるのは変な感じがするので、 `||` でという感じに。

### レビュアー

どなたでも