### PR TITLE
タスク一覧を作成日時の順番で並び替える

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ group :test do
   gem 'chromedriver-helper'
   gem 'rspec'
   gem 'rspec-rails'
+  gem 'factory_bot_rails'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ group :development, :test do
   gem 'pry-byebug' 
   gem 'pry-stack_explorer' 
   gem 'rubocop', require: false
+  gem 'faker'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,8 @@ GEM
     diff-lcs (1.3)
     erubi (1.7.1)
     execjs (2.7.0)
+    faker (1.8.7)
+      i18n (>= 0.7)
     ffi (1.9.25)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
@@ -256,6 +258,7 @@ DEPENDENCIES
   capybara (>= 2.15, < 4.0)
   chromedriver-helper
   coffee-rails (~> 4.2)
+  faker
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   pg

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,11 @@ GEM
     diff-lcs (1.3)
     erubi (1.7.1)
     execjs (2.7.0)
+    factory_bot (4.10.0)
+      activesupport (>= 3.0.0)
+    factory_bot_rails (4.10.0)
+      factory_bot (~> 4.10.0)
+      railties (>= 3.0.0)
     faker (1.8.7)
       i18n (>= 0.7)
     ffi (1.9.25)
@@ -259,6 +264,7 @@ DEPENDENCIES
   capybara (>= 2.15, < 4.0)
   chromedriver-helper
   coffee-rails (~> 4.2)
+  factory_bot_rails
   faker
   http_accept_language
   jbuilder (~> 2.5)

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -3,7 +3,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
   def index
-    @tasks = Task.all
+    @tasks = Task.all.order(created_at: 'DESC')
   end
 
   def new

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -3,7 +3,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
   def index
-    @tasks = Task.all.order(created_at: 'DESC')
+    @tasks = Task.order(created_at: 'DESC')
   end
 
   def new

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,14 +1,25 @@
-<ul>
-<% @tasks.each do |task| %>
-  <li>
-    <p>
-      <%= task.title %>
-      <%= link_to t('view.common.link_text.edit'), edit_task_path(task) %>
-      <%= link_to t('view.common.link_text.delete'),
+<table>
+  <thead>
+    <tr>
+      <th>タスク</th>
+      <th>作成日時</th>
+      <th>期限</th>
+      <th>詳細</th>
+      <th>操作</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @tasks.each do |task| %>
+      <tr>
+        <td><%= task.title %></td>
+        <td><%= l(task.created_at, format: :long) %></td>
+        <td><%= l(task.expire_at, format: :long) %></td>
+        <td><%= link_to t('view.common.link_text.edit'), edit_task_path(task) %></td>
+        <td><%= link_to t('view.common.link_text.delete'),
           task_path(task), method: :delete,
-          data: {confirm: t('view.task.message.delete_confirm')} %>
-    </p>
-  </li>
-<% end %>
-</ul>
+          data: {confirm: t('view.task.message.delete_confirm')} %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
 <%= link_to t('view.common.link_text.new'), new_task_path %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -3,6 +3,7 @@
   <li>
     <p>
       <%= task.title %>
+      <%= task.created_at %>
       <%= link_to "編集", edit_task_path(task) %>  
       <%= link_to "削除", task_path(task), method: :delete, data: {confirm: "本当に削除しますか？"} %>
     </p>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,4 +1,4 @@
-<table>
+<table id="task_table">
   <thead>
     <tr>
       <th>タスク</th>
@@ -8,14 +8,14 @@
       <th>操作</th>
     </tr>
   </thead>
-  <tbody>
+  <tbody id="task_table_body">
     <% @tasks.each do |task| %>
       <tr>
-        <td><%= task.title %></td>
-        <td><%= l(task.created_at, format: :long) %></td>
-        <td><%= l(task.expire_at, format: :long) %></td>
-        <td><%= link_to t('view.common.link_text.edit'), edit_task_path(task) %></td>
-        <td><%= link_to t('view.common.link_text.delete'),
+        <td id="title"><%= task.title %></td>
+        <td id="created_at"><%= l(task.created_at, format: :long) %></td>
+        <td id="expire_at"><%= l(task.expire_at, format: :long) %></td>
+        <td id="edit_link"><%= link_to t('view.common.link_text.edit'), edit_task_path(task) %></td>
+        <td id="delte_link"><%= link_to t('view.common.link_text.delete'),
           task_path(task), method: :delete,
           data: {confirm: t('view.task.message.delete_confirm')} %></td>
       </tr>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,7 +2,7 @@ require 'faker'
 
 10.times do |i|
   created_at = Faker::Time.forward.to_datetime
-  expire_at = created_at + 1
+  expire_at = created_at + 2.days
   Task.create(
     title:    "タスク#{i}",
     description:  "内容#{i}",

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,13 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+require 'faker'
+
+10.times do |i|
+  created_at = Faker::Time.forward.to_datetime
+  expire_at = created_at + 1
+  Task.create(
+    title:    "タスク#{i}",
+    description:  "内容#{i}",
+    priority: 1,
+    expire_at: expire_at,
+    created_at: created_at
+  )
+end

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -1,10 +1,12 @@
 require 'factory_bot'
+require 'faker'
 
 FactoryBot.define do
   factory :task do
     title 'タスク1'
     description 'これはテストです'
-    expire_at '2019-01-01 00:00:00'
+    expire_at { Faker::Time.forward.to_datetime }
+    created_at { Faker::Time.backward.to_datetime }
     priority 1
   end
 end

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -1,0 +1,10 @@
+require 'factory_bot'
+
+FactoryBot.define do
+  factory :task do
+    title 'タスク1'
+    description 'これはテストです'
+    expire_at '2019-01-01 00:00:00'
+    priority 1
+  end
+end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -6,7 +6,7 @@ describe 'Task' do
   end
 
   example 'タスクが作成できて、メッセージが表示されること' do
-    visit '/tasks/new'
+    visit new_task_path
     fill_in 'Title', with: 'タスク1'
     fill_in 'Description', with: 'これはテスト用のタスクです'
     fill_in 'Expire at', with: '2019-01-01 00:00:00'
@@ -26,13 +26,13 @@ describe 'Task' do
   end
 
   example 'タスクの削除ができて、メッセージが表示されること' do
-    visit '/tasks/'
+    visit tasks_path
     expect { click_link '削除', match: :first }.to change(Task, :count).by(-1)
     expect(page).to have_content I18n.t('view.task.message.deleted')
   end
 
   example 'タスクが降順で表示されること' do
-    visit '/'
+    visit tasks_path
     @created_at_elements = page.all('#created_at')
     expect(@created_at_elements.size).to eq(3)
 

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe 'Task' do
   before do
-    @task = create(:task)
+    @task = create_list(:task, 3)
   end
 
   example 'タスクが作成できて、メッセージが表示されること' do
@@ -27,7 +27,16 @@ describe 'Task' do
 
   example 'タスクの削除ができて、メッセージが表示されること' do
     visit '/tasks/'
-    expect { click_link '削除' }.to change(Task, :count).by(-1)
+    expect { click_link '削除', match: :first }.to change(Task, :count).by(-1)
     expect(page).to have_content I18n.t('view.task.message.deleted')
+  end
+
+  example 'タスクが降順で表示されること' do
+    visit '/'
+    @created_at_elements = page.all('#created_at')
+    expect(@created_at_elements.size).to eq(3)
+
+    @created_at_days = @created_at_elements.map(&:text)
+    expect(@created_at_days).to eq(@created_at_days.sort.reverse)
   end
 end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -33,10 +33,7 @@ describe 'Task' do
 
   example 'タスクが降順で表示されること' do
     visit tasks_path
-    @created_at_elements = page.all('#created_at')
-    expect(@created_at_elements.size).to eq(3)
-
-    @created_at_days = @created_at_elements.map(&:text)
+    @created_at_days = page.all('#created_at').map(&:text)
     expect(@created_at_days).to eq(@created_at_days.sort.reverse)
   end
 end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -2,10 +2,7 @@ require 'rails_helper'
 
 describe 'Task' do
   before do
-    @task = Task.create(
-      title: 'タスク', description: 'これはテスト用のタスクです',
-      expire_at: '2019-01-01 00:00:00', priority: 1
-    )
+    @task = create(:task)
   end
 
   example 'タスクが作成できて、メッセージが表示されること' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -56,4 +56,7 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  # FactoryBot configure
+  config.include FactoryBot::Syntax::Methods
 end


### PR DESCRIPTION
### このPRで解決すること

タスクの一覧画面で表示されるタスクを作成日時の降順で並び替えます。

<img width="470" alt="2018-06-28 14 34 14" src="https://user-images.githubusercontent.com/5842353/42015030-5ef50bec-7ae0-11e8-944a-26e48115ff5e.png">

※ 間隔が狭くて見づらいですが、これは後の「ステップ18: デザインを当てよう」で修正する予定です。

factory_bot を導入してテストデータを生成する変更を加えたため、変更が大きく見えますが、tasks_controller で

```ruby
Task.all.order(created_at: 'DESC')
```

しただけです。

### レビューしてほしいところ

- 降順であることを確認する手段が正しいか
  - task の作成日時を `page.all('#created_at)` でArrayで取得した
  - その後、`sort.reverse` でしたものと比較して等価であることを確認している

### レビュアー

@june29 、どなたでも

---

ref: https://github.com/everyleaf/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9711-%E3%82%BF%E3%82%B9%E3%82%AF%E4%B8%80%E8%A6%A7%E3%82%92%E4%BD%9C%E6%88%90%E6%97%A5%E6%99%82%E3%81%AE%E9%A0%86%E7%95%AA%E3%81%A7%E4%B8%A6%E3%81%B3%E6%9B%BF%E3%81%88%E3%82%88%E3%81%86