### PR TITLE
Taskモデルのバリデーションを追加

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,2 +1,21 @@
 class Task < ApplicationRecord
+  validates :title,
+    presence: { message: I18n.t('view.task.message.error.required') }
+
+  validates :priority,
+    numericality: { only_integer: true }, unless: :priority_is_nil?
+
+  validate :expire_greater_than_current_time
+
+  def priority_is_nil?
+    priority.nil?
+  end
+
+  def expire_greater_than_current_time
+    return if expire_at.nil?
+
+    if expire_at <= Time.zone.now
+      errors.add :base, I18n.t('view.task.message.error.expire_greater_than_current_time')
+    end
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,9 @@ en:
         updated: "Updated a task"
         deleted: "Deleted a task"
         delete_confirm: "Are you sure you want to delte the task?"
+        error:
+          required: "is required"
+          expire_greater_than_current_time: "The expire can not be set to the past time"
       title:
         new: "Create new task"
     common:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,6 +7,9 @@ ja:
         updated: "タスクを更新しました"
         deleted: "タスクを削除しました"
         delete_confirm: "本当に削除しますか？"
+        error:
+          required: "は必須です"
+          expire_greater_than_current_time: "期限を過去の時間に設定することはできません"
       title:
         new: "タスクの新規作成"
     common:

--- a/db/migrate/20180628083935_validate_task.rb
+++ b/db/migrate/20180628083935_validate_task.rb
@@ -1,0 +1,8 @@
+class ValidateTask < ActiveRecord::Migration[5.2]
+  def change
+    # タイトルはNULL禁止で
+    change_column_null :tasks, :title, false
+    # INDEX
+    add_index :tasks, [:title, :description, :priority]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,18 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_19_053235) do
+ActiveRecord::Schema.define(version: 2018_06_28_083935) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "tasks", force: :cascade do |t|
-    t.string "title"
+    t.string "title", null: false
     t.text "description"
     t.integer "priority"
     t.datetime "expire_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["title", "description", "priority"], name: "index_tasks_on_title_and_description_and_priority"
   end
 
 end

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -27,5 +27,12 @@ FactoryBot.define do
       expire_at { Faker::Time.forward.to_datetime }
       priority 'wei'
     end
+
+    factory :priority_is_nil_task do
+      title 'タスク1'
+      description 'これは優先度がnilなタスクです'
+      expire_at { Faker::Time.forward.to_datetime }
+      priority nil
+    end
   end
 end

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -8,5 +8,24 @@ FactoryBot.define do
     expire_at { Faker::Time.forward.to_datetime }
     created_at { Faker::Time.backward.to_datetime }
     priority 1
+
+    factory :expire_of_past_task do
+      title 'タスク1'
+      description 'これは期日が過去の日時のタスクです'
+      expire_at { Faker::Time.backward.to_datetime }
+      priority 1
+    end
+
+    factory :nontitle_task do
+      title ''
+      description 'これはタイトルがないタスクです'
+    end
+
+    factory :priority_is_not_integer_task do
+      title 'タスク1'
+      description 'これは優先度が数値ではないタスクです'
+      expire_at { Faker::Time.forward.to_datetime }
+      priority 'wei'
+    end
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+describe Task, type: :model do
+  context 'Taskを作成するとき' do
+    it '正常に作成できること' do
+      task = Task.new(
+        title: 'タスク1',
+        description: '正常系タスク1',
+        priority: 1,
+        expire_at: '2019-12-24 00:00:00'
+      )
+      expect(task).to be_valid
+    end
+
+    it 'titleが入っていないと作成できないこと' do
+      task = Task.new
+      task.valid?
+      expect(task.errors[:title].size).to eq(1)
+    end
+
+    it '期日が作成日時より過去の場合は作成できないこと' do
+      task = Task.new(
+        title: 'タスク2',
+        description: '異常系タスク2',
+        priority: 1,
+        expire_at: '1995-12-24 00:00:00'
+      )
+      task.valid?
+      expect(task.errors.size).to eq(1)
+    end
+
+    it '優先度が数字じゃない場合は作成できないこと' do
+      task = Task.new(
+        title: 'タスク2',
+        description: '異常系タスク2',
+        priority: 'wei',
+        expire_at: '2020-12-24 00:00:00'
+      )
+      task.valid?
+      expect(task.errors[:priority].size).to eq(1)
+    end
+  end
+end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -3,39 +3,24 @@ require 'rails_helper'
 describe Task, type: :model do
   context 'Taskを作成するとき' do
     it '正常に作成できること' do
-      task = Task.new(
-        title: 'タスク1',
-        description: '正常系タスク1',
-        priority: 1,
-        expire_at: '2019-12-24 00:00:00'
-      )
+      task = build(:task)
       expect(task).to be_valid
     end
 
     it 'titleが入っていないと作成できないこと' do
-      task = Task.new
+      task = build(:nontitle_task)
       task.valid?
       expect(task.errors[:title].size).to eq(1)
     end
 
     it '期日が作成日時より過去の場合は作成できないこと' do
-      task = Task.new(
-        title: 'タスク2',
-        description: '異常系タスク2',
-        priority: 1,
-        expire_at: '1995-12-24 00:00:00'
-      )
+      task = build(:expire_of_past_task)
       task.valid?
       expect(task.errors.size).to eq(1)
     end
 
     it '優先度が数字じゃない場合は作成できないこと' do
-      task = Task.new(
-        title: 'タスク2',
-        description: '異常系タスク2',
-        priority: 'wei',
-        expire_at: '2020-12-24 00:00:00'
-      )
+      task = build(:priority_is_not_integer_task)
       task.valid?
       expect(task.errors[:priority].size).to eq(1)
     end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -24,5 +24,10 @@ describe Task, type: :model do
       task.valid?
       expect(task.errors[:priority].size).to eq(1)
     end
+
+    it '優先度がnilのときは作成できること' do
+      task = build(:priority_is_nil_task)
+      expect(task).to be_valid
+    end
   end
 end


### PR DESCRIPTION
### このPRで解決すること

Taskモデルにバリデーションを追加し、不正なタスクが登録されることを防ぎます。
Taskモデルには以下のバリデーションを追加しました。

##### 1. タイトルが空ではないこと
  - タイトルのないタスクは登録できません

##### 2. priorityは数字であること
  - ただし、優先度を設定したくないときもあるため、`NOT NULL` ではないです

##### 3. 期日が現在時刻より過去でないこと
  - 期日は必ず現在時刻より先の時刻であるため、過去の時刻である場合は拒否します

---

また、データベースの方にも以下の設定を行いました。

- title に `NOT NULL` を付与
- title, description, priority に `INDEX` を貼った
  - これらのカラムで検索を行いたいという要件があったため

---

小さな変更として、これらのバリデーションエラーが発生したときに表示するエラーメッセージの定義を `locales` に追記しました。

### レビュアー

@june29 , 誰でも

---

ref : https://github.com/everyleaf/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9712-%E3%83%90%E3%83%AA%E3%83%87%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%82%92%E8%A8%AD%E5%AE%9A%E3%81%97%E3%82%88%E3%81%86