### PR TITLE
期限が nil のときに index で正しく表示されないのを修正

### DIFF
--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -13,7 +13,7 @@
       <tr>
         <td id="title"><%= task.title %></td>
         <td id="created_at"><%= l(task.created_at, format: :long) %></td>
-        <td id="expire_at"><%= l(task.expire_at, format: :long) %></td>
+        <td id="expire_at"><%= l(task.expire_at, format: :long) unless task.expire_at.nil? %></td>
         <td id="edit_link"><%= link_to t('view.common.link_text.edit'), edit_task_path(task) %></td>
         <td id="delte_link"><%= link_to t('view.common.link_text.delete'),
           task_path(task), method: :delete,

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -36,4 +36,17 @@ describe 'Task' do
     @created_at_days = page.all('#created_at').map(&:text)
     expect(@created_at_days).to eq(@created_at_days.sort.reverse)
   end
+
+  example '期限がnilのタスクが作成できて、正しく表示されること' do
+    visit new_task_path
+    fill_in 'Title', with: 'non-expire-task'
+    fill_in 'Description', with: 'これは期限が設定されていないタスクです'
+    fill_in 'Expire at', with: ''
+    fill_in 'Priority', with: '1'
+    find(:xpath, '/html[1]/body[1]/form[1]/div[@class="actions"]/input[1]').click
+    expect(page).to have_content I18n.t('view.task.message.created')
+    expect(Task.exists?(title: 'non-expire-task')).to be_truthy
+    visit tasks_path
+    expect(page).to have_http_status(200)
+  end
 end


### PR DESCRIPTION
### このPRで解決すること

期限 (expire_at) が `nil` のときに、`/views/tasks/index.html.erb` でエラーとなってしまっていた。
原因としては `l(task.expire_at, format: :long)` の部分で、 `nil` に対して DateTime に変換しようとしてしまっていたため。

### 解決方法

`expire_at` が nil じゃないときだけ `expire_at` を表示するにした。

### レビュアー

@june29 , 誰でも

