### PR TITLE
終了期限が近い順にソートできるように

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -3,7 +3,12 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
   def index
-    @tasks = Task.order(created_at: 'DESC')
+    # デフォルトで作成日時の降順で返す
+    @tasks = if params[:sort] == 'expire'
+               Task.order(expire_at: 'ASC')
+             else
+               Task.order(created_at: 'DESC')
+             end
   end
 
   def new

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -3,7 +3,6 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
   def index
-    # デフォルトで作成日時の降順で返す
     @tasks = if params[:sort] == 'expire'
                Task.order(expire_at: 'ASC')
              else

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,3 +1,6 @@
+<%= link_to t('view.task.link_text.sort_by_expire'), tasks_path(sort: 'expire'), id: "sort_by_expire"  %> | 
+<%= link_to t('view.task.link_text.sort_by_created_at'), tasks_path, id: "sort_by_created_at" %>
+<hr />
 <table id="task_table">
   <thead>
     <tr>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,9 @@ en:
           expire_greater_than_current_time: "The expire can not be set to the past time"
       title:
         new: "Create new task"
+      link_text:
+        sort_by_expire: "Sort by due date"
+        sort_by_created_at: "Sort by new created date"
     common:
       button_text:
         create: "Create"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -12,6 +12,9 @@ ja:
           expire_greater_than_current_time: "期限を過去の時間に設定することはできません"
       title:
         new: "タスクの新規作成"
+      link_text:
+        sort_by_expire: "終了期限が近い順"
+        sort_by_created_at: "作成日時が新しい順"
     common:
       button_text:
         create: "作成する"

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -54,10 +54,7 @@ describe 'Task' do
     visit tasks_path
     click_link('sort_by_expire')
     @expire_at_days = page.all('#expire_at').map(&:text)
-    # @expect_days = Task.order(expire_at: 'ASC').map { |t| t.expire_at&.strftime('%Y/%m/%d %H:%M') }
-    # expect(@expire_at_days).to eq(@expect_days)
-    # このテストは失敗する
-    @not_expect_days = Task.order(created_at: 'DESC').map { |t| t.expire_at&.strftime('%Y/%m/%d %H:%M') }
-    expect(@expire_at_days).to eq(@not_expect_days)
+    @expect_days = Task.order(expire_at: 'ASC').map { |t| t.expire_at&.strftime('%Y/%m/%d %H:%M') }
+    expect(@expire_at_days).to eq(@expect_days)
   end
 end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -49,4 +49,15 @@ describe 'Task' do
     visit tasks_path
     expect(page).to have_http_status(200)
   end
+
+  example '期限が近い順でソートされること(このテストは失敗する)' do
+    visit tasks_path
+    click_link('sort_by_expire')
+    @expire_at_days = page.all('#expire_at').map(&:text)
+    # @expect_days = Task.order(expire_at: 'ASC').map { |t| t.expire_at&.strftime('%Y/%m/%d %H:%M') }
+    # expect(@expire_at_days).to eq(@expect_days)
+    # このテストは失敗する
+    @not_expect_days = Task.order(created_at: 'DESC').map { |t| t.expire_at&.strftime('%Y/%m/%d %H:%M') }
+    expect(@expire_at_days).to eq(@not_expect_days)
+  end
 end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -50,7 +50,7 @@ describe 'Task' do
     expect(page).to have_http_status(200)
   end
 
-  example '期限が近い順でソートされること(このテストは失敗する)' do
+  example '期限が近い順でソートされること' do
     visit tasks_path
     click_link('sort_by_expire')
     @expire_at_days = page.all('#expire_at').map(&:text)


### PR DESCRIPTION
### 解決すること

タスク一覧画面でタスクの終了期限が近い順にソートできるようにしました。

<img width="490" alt="2018-07-03 10 41 44" src="https://user-images.githubusercontent.com/5842353/42194274-18984dc2-7eae-11e8-81bf-5d49f00fd911.png">

終了期限が近い順 というボタンをクリックすることでソートされます。

### 実装

```ruby
  def index
    # デフォルトで作成日時の降順で返す
    @tasks = if params[:sort] == 'expire'
               Task.order(expire_at: 'ASC')
             else
               Task.order(created_at: 'DESC')
             end
  end
```

```erb
<%= link_to t('view.task.link_text.sort_by_expire'), tasks_path(sort: 'expire'), id: "sort_by_expire"  %>
```

`sort` パラメータが `expire` の場合は終了期限が近い順に並び替えて表示するようにしました。
それ以外の場合は、これまで通り、作成日時の降順で表示されます。

##### フロントエンドのJavaScriptで並び替えない理由

- タスクの数が増えた場合にページネーションが発生するため、一画面にすべてのタスクが収まることがない
  - そのため、すべてのタスクをソートしようとすると、結局アプリケーションへの問い合わせが発生するため

### レビュアー

@june29 , 誰でも


