### PR TITLE
タスクに「未着手」「着手中」「完了」のステータスを追加する

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,6 @@
 class Task < ApplicationRecord
+  enum status: { not_started: 0, in_progress: 1, done: 2 }
+
   validates :title,
     presence: { message: I18n.t('view.task.message.error.required') }
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,5 +1,5 @@
 class Task < ApplicationRecord
-  enum status: { not_started: 0, in_progress: 1, done: 2 }
+  enum status: { todo: 0, doing: 1, done: 2 }
 
   validates :title,
     presence: { message: I18n.t('view.task.message.error.required') }

--- a/db/migrate/20180704023918_add_status_column_to_task.rb
+++ b/db/migrate/20180704023918_add_status_column_to_task.rb
@@ -1,0 +1,8 @@
+class AddStatusColumnToTask < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tasks, :status, :integer, default: 0
+    # わざとindexは貼りません
+    # 今後の作業内容で 検索インデックスを貼りましょう があり、
+    # 速度が改善されることを確認する作業があるため
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_28_083935) do
+ActiveRecord::Schema.define(version: 2018_07_04_023918) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 2018_06_28_083935) do
     t.datetime "expire_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0
     t.index ["title", "description", "priority"], name: "index_tasks_on_title_and_description_and_priority"
   end
 

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -32,16 +32,16 @@ describe Task, type: :model do
 
     it 'ステータスがデフォルトで未着手であること' do
       task = build(:task)
-      expect(task.status).to eq('not_started')
+      expect(task.status).to eq('todo')
     end
 
     it 'ステータスを変更できること' do
       task = build(:task)
       # 着手中に変更する
-      task.in_progress!
+      task.doing!
       expect(task).to be_valid
       task.save
-      expect(task.status).to eq('in_progress')
+      expect(task.status).to eq('doing')
 
       # 完了に変更する
       task.done!

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -29,5 +29,25 @@ describe Task, type: :model do
       task = build(:priority_is_nil_task)
       expect(task).to be_valid
     end
+
+    it 'ステータスがデフォルトで未着手であること' do
+      task = build(:task)
+      expect(task.status).to eq('not_started')
+    end
+
+    it 'ステータスを変更できること' do
+      task = build(:task)
+      # 着手中に変更する
+      task.in_progress!
+      expect(task).to be_valid
+      task.save
+      expect(task.status).to eq('in_progress')
+
+      # 完了に変更する
+      task.done!
+      expect(task).to be_valid
+      task.save
+      expect(task.status).to eq('done')
+    end
   end
 end


### PR DESCRIPTION
### 概要

タスクに「未着手」・「着手中」・「完了」の3種類の状態（ステータス）を管理できるようにします。

タスクがにこれらの状態が複数重なることはなく、常にいずれかの状態を1つのみ持つはずなので、`Task` モデルに `ActiveRecord::Enum` で `status` カラムを追加することにしました。

未着手、着手中、完了をそれぞれ not_started, in_progress, done で表現します。

タスク作成時のデフォルト値は「 `未着手` 」です。

##### indexは貼っていません

検索を行うために、これらステータスには index を張る必要がありますが、今後の作業で「検索インデックスを貼りましょう」があるので、ここでは貼らずに後の作業で張ることにします。

### レビュアー

@june29 , 誰でも

---

ref : https://github.com/everyleaf/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9715-%E3%82%B9%E3%83%86%E3%83%BC%E3%82%BF%E3%82%B9%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%81%A6%E6%A4%9C%E7%B4%A2%E3%81%A7%E3%81%8D%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%97%E3%82%88%E3%81%86