### PR TITLE
タイトルとステータスで検索を行うためのメソッドを生やした

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -3,13 +3,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
   def index
-    @tasks = if params[:sort] == 'expire'
-               Task.order(expire_at: 'ASC')
-                   .search_by_title_and_status(params)
-             else
-               Task.order(created_at: 'DESC')
-                   .search_by_title_and_status(params)
-             end
+    @tasks = Task.filter_by_title_and_status(params)
   end
 
   def new

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -5,8 +5,10 @@ class TasksController < ApplicationController
   def index
     @tasks = if params[:sort] == 'expire'
                Task.order(expire_at: 'ASC')
+                   .search_by_title_and_status(params)
              else
                Task.order(created_at: 'DESC')
+                   .search_by_title_and_status(params)
              end
   end
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -9,8 +9,9 @@ class Task < ApplicationRecord
 
   validate :expire_greater_than_current_time
 
-  scope :search_by_title, ->(title) { where('title like ?', '%' + title + '%') unless title.nil? }
-  scope :search_by_status, ->(status) { where(status: status) unless status.nil? }
+  scope :filter_by_title, ->(title) { where('title like ?', "%#{title}%") unless title.nil? }
+  scope :filter_by_status, ->(status) { where(status: status) unless status.nil? }
+  scope :sort_by_expire, ->(sort) { sort == 'expire' ? order(expire_at: 'ASC') : order(created_at: 'DESC') }
 
   def priority_is_nil?
     priority.nil?
@@ -24,7 +25,9 @@ class Task < ApplicationRecord
     end
   end
 
-  def self.search_by_title_and_status(params)
-    search_by_title(params[:title]).search_by_status(params[:status])
+  def self.filter_by_title_and_status(params)
+    filter_by_title(params[:title])
+      .filter_by_status(params[:status])
+      .sort_by_expire(params[:sort])
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -9,6 +9,9 @@ class Task < ApplicationRecord
 
   validate :expire_greater_than_current_time
 
+  scope :search_by_title, ->(title) { where('title like ?', '%' + title + '%') unless title.nil? }
+  scope :search_by_status, ->(status) { where(status: status) unless status.nil? }
+
   def priority_is_nil?
     priority.nil?
   end
@@ -19,5 +22,9 @@ class Task < ApplicationRecord
     if expire_at <= Time.zone.now
       errors.add :base, I18n.t('view.task.message.error.expire_greater_than_current_time')
     end
+  end
+
+  def self.search_by_title_and_status(params)
+    search_by_title(params[:title]).search_by_status(params[:status])
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -55,38 +55,38 @@ describe Task, type: :model do
     task = create(:task)
     # タスク1が見つかること
     params = { title: '1' }
-    expect(Task.search_by_title_and_status(params).count).to eq(1)
+    expect(Task.filter_by_title_and_status(params).count).to eq(1)
 
     # タスクが見つからないこと
     params = { title: 'non-exist-task' }
-    expect(Task.search_by_title_and_status(params).count).to eq(0)
+    expect(Task.filter_by_title_and_status(params).count).to eq(0)
   end
 
   it 'ステータスで検索ができること' do
     task = create(:task)
     # タスク1が見つかること
     params = { status: 'todo' }
-    expect(Task.search_by_title_and_status(params).count).to eq(1)
+    expect(Task.filter_by_title_and_status(params).count).to eq(1)
 
     # タスクが見つからないこと
     task.doing!
     task.save
     params = { status: 'todo' }
-    expect(Task.search_by_title_and_status(params).count).to eq(0)
+    expect(Task.filter_by_title_and_status(params).count).to eq(0)
 
     # タスク1が見つかること
     params = { status: 'doing' }
-    expect(Task.search_by_title_and_status(params).count).to eq(1)
+    expect(Task.filter_by_title_and_status(params).count).to eq(1)
   end
 
   it 'タイトルとステータスで検索ができること' do
     task = create(:task)
     # タスク1が見つかること
     params = { title: '1', status: 'todo' }
-    expect(Task.search_by_title_and_status(params).count).to eq(1)
+    expect(Task.filter_by_title_and_status(params).count).to eq(1)
 
     # タスクが見つからないこと
     params = { title: '1', status: 'doing' }
-    expect(Task.search_by_title_and_status(params).count).to eq(0)
+    expect(Task.filter_by_title_and_status(params).count).to eq(0)
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -78,4 +78,15 @@ describe Task, type: :model do
     params = { status: 'doing' }
     expect(Task.search_by_title_and_status(params).count).to eq(1)
   end
+
+  it 'タイトルとステータスで検索ができること' do
+    task = create(:task)
+    # タスク1が見つかること
+    params = { title: '1', status: 'todo' }
+    expect(Task.search_by_title_and_status(params).count).to eq(1)
+
+    # タスクが見つからないこと
+    params = { title: '1', status: 'doing' }
+    expect(Task.search_by_title_and_status(params).count).to eq(0)
+  end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -50,4 +50,32 @@ describe Task, type: :model do
       expect(task.status).to eq('done')
     end
   end
+
+  it 'タイトルであいまい検索ができること' do
+    task = create(:task)
+    # タスク1が見つかること
+    params = { title: '1' }
+    expect(Task.search_by_title_and_status(params).count).to eq(1)
+
+    # タスクが見つからないこと
+    params = { title: 'non-exist-task' }
+    expect(Task.search_by_title_and_status(params).count).to eq(0)
+  end
+
+  it 'ステータスで検索ができること' do
+    task = create(:task)
+    # タスク1が見つかること
+    params = { status: 'todo' }
+    expect(Task.search_by_title_and_status(params).count).to eq(1)
+
+    # タスクが見つからないこと
+    task.doing!
+    task.save
+    params = { status: 'todo' }
+    expect(Task.search_by_title_and_status(params).count).to eq(0)
+
+    # タスク1が見つかること
+    params = { status: 'doing' }
+    expect(Task.search_by_title_and_status(params).count).to eq(1)
+  end
 end


### PR DESCRIPTION
### 概要

Task をタイトルとステータスで検索が行えるように Task モデルにメソッドを生やしました。
タイトルはあいまい検索ができるようにしています。
ステータスは今後多くなっても10個以内ぐらいだと思っていて、 View ではプルダウンで表示するので、
あいまい検索ではなく、完全一致という形にしました。

検索を行うために Ransack も検討しましたが、この程度であれば （今後検索するフィールドが増えることもなさそうなことも考えて）Ransackに頼らなくても良いかなという判断をしました。
できるだけ Controller を薄くするために Model にメソッドを生やしました。

`title` と `status` の両方で確認する場合にそれぞれ `.prevent?` で確認するのは冗長になると思ったので、 `scope` でそれぞれ作り、今回の最終的な目的である `タイトルとステータスで検索を行う` ためのメソッド `search_by_title_and_status` を作ったというのが作業の過程です。

### レビューしてほしいところ

- `search_by_title_and_status` という名前が長い気がするがRuby的にどうか
  - Rubocopには怒られなかった
- `scope` で分けて `params` をエイッと渡す方法はレールに載っているか
  - `if params[:title].prevent? ...` で分岐するのは冗長だと思ったためです
- テストはこれで十分か
  - `search_by_title_and_status` の動作を十分に保証できているか

###  レビュアー

@june29 , 誰でも

---

ref : https://github.com/everyleaf/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9715-%E3%82%B9%E3%83%86%E3%83%BC%E3%82%BF%E3%82%B9%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%81%A6%E6%A4%9C%E7%B4%A2%E3%81%A7%E3%81%8D%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%97%E3%82%88%E3%81%86