### PR TITLE
タイトルとステータスで検索するフォームを追加

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -4,6 +4,7 @@ class TasksController < ApplicationController
 
   def index
     @tasks = Task.filter_by_title_and_status(params)
+    @statuses = Task.statuses
   end
 
   def new

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -9,8 +9,8 @@ class Task < ApplicationRecord
 
   validate :expire_greater_than_current_time
 
-  scope :filter_by_title, ->(title) { where('title like ?', "%#{title}%") unless title.nil? }
-  scope :filter_by_status, ->(status) { where(status: status) unless status.nil? }
+  scope :filter_by_title, ->(title) { where('title like ?', "%#{title}%") unless title.blank? }
+  scope :filter_by_status, ->(status) { where(status: status) unless status.blank? }
   scope :sort_by_expire, ->(sort) { sort == 'expire' ? order(expire_at: 'ASC') : order(created_at: 'DESC') }
 
   def priority_is_nil?

--- a/app/views/tasks/_search_form.erb
+++ b/app/views/tasks/_search_form.erb
@@ -1,0 +1,5 @@
+<%= form_tag(tasks_path, method: :get) do |f| %>
+  <%= text_field_tag :title %>
+  <%= select_tag :status, options_for_select(@statuses), include_blank: true %>
+  <%= submit_tag t('view.common.button_text.search.') %>
+<% end %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,10 +1,14 @@
 <%= link_to t('view.task.link_text.sort_by_expire'), tasks_path(sort: 'expire'), id: "sort_by_expire"  %> | 
 <%= link_to t('view.task.link_text.sort_by_created_at'), tasks_path, id: "sort_by_created_at" %>
+
+<%= render 'search_form' %>
+
 <hr />
 <table id="task_table">
   <thead>
     <tr>
       <th>タスク</th>
+      <th>ステータス</th>
       <th>作成日時</th>
       <th>期限</th>
       <th>詳細</th>
@@ -15,6 +19,7 @@
     <% @tasks.each do |task| %>
       <tr>
         <td id="title"><%= task.title %></td>
+        <td id="title"><%= task.status %></td>
         <td id="created_at"><%= l(task.created_at, format: :long) %></td>
         <td id="expire_at"><%= l(task.expire_at, format: :long) unless task.expire_at.nil? %></td>
         <td id="edit_link"><%= link_to t('view.common.link_text.edit'), edit_task_path(task) %></td>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -19,7 +19,7 @@
     <% @tasks.each do |task| %>
       <tr>
         <td id="title"><%= task.title %></td>
-        <td id="title"><%= task.status %></td>
+        <td id="status"><%= task.status %></td>
         <td id="created_at"><%= l(task.created_at, format: :long) %></td>
         <td id="expire_at"><%= l(task.expire_at, format: :long) unless task.expire_at.nil? %></td>
         <td id="edit_link"><%= link_to t('view.common.link_text.edit'), edit_task_path(task) %></td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,7 @@ en:
         create: "Create"
         update: "Update"
         delete: "Delete"
+        search: "Search"
       link_text:
         new: "New"
         edit: "Edit"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -20,6 +20,7 @@ ja:
         create: "作成する"
         update: "更新する"
         delete: "削除する"
+        search: "検索"
       link_text:
         new: "新規作成"
         edit: "編集"

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -34,5 +34,17 @@ FactoryBot.define do
       expire_at { Faker::Time.forward.to_datetime }
       priority nil
     end
+
+    factory :status_is_doing_task do
+      title 'doing-task'
+      description 'これはstatusがdoingなタスクです'
+      priority 1
+    end
+
+    factory :status_is_done_task do
+      title 'done-task'
+      description 'これはstatusがdoneなタスクです'
+      priority 1
+    end
   end
 end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -64,6 +64,7 @@ describe 'Task' do
     visit '/'
     fill_in 'title', with: 'タスク'
     find(:xpath, '/html[1]/body[1]/form[1]/input[3]').click
+    # %E3%82%BF%E3%82%B9%E3%82%AF1 = タスク
     visit '/tasks?title=%E3%82%BF%E3%82%B9%E3%82%AF1&status='
     expect(page.all('tbody tr').count).to eq(Task.where("title like '%タスク%'").count)
   end
@@ -72,7 +73,7 @@ describe 'Task' do
     visit '/'
     select 'doing', from: 'status'
     find(:xpath, '/html[1]/body[1]/form[1]/input[3]').click
-    visit '/tasks?utf8=%E2%9C%93&title=&status=1&commit=%E6%A4%9C%E7%B4%A2'
+    visit '/tasks?title=&status=1'
     expect(page.all('tbody tr').count).to eq(Task.doing.count)
   end
 
@@ -81,7 +82,9 @@ describe 'Task' do
     fill_in 'title', with: 'task'
     select 'doing', from: 'status'
     find(:xpath, '/html[1]/body[1]/form[1]/input[3]').click
-    visit '/tasks?utf8=%E2%9C%93&title=task&status=1&commit=%E6%A4%9C%E7%B4%A2'
-    expect(page.all('tbody tr').count).to eq(Task.filter_by_title('task').filter_by_status('doing').count)
+    # タイトルが「task」を含み、かつ、doingであるものを検索
+    visit '/tasks?title=task&status=1'
+    expect_task = Task.filter_by_title('task').filter_by_status('doing')
+    expect(page.all('tbody tr').count).to eq(expect_task.count)
   end
 end


### PR DESCRIPTION
### 概要

タスクの一覧ページでタイトルとステータスでタスクを検索できるようにします。

<img width="549" alt="2018-07-09 17 58 42" src="https://user-images.githubusercontent.com/5842353/42440867-c07a9980-83a1-11e8-87e2-9302d18a519e.png">

### 変更点

1. Task モデルの `filter_by_title` と `filter_by_status` で送信されてきたパラメータが `nil` の場合はクエリを発行しないようにしてましたが、リクエストが **値は存在しないがパラメータは存在する** ( `title=task&status=` のような感じ) になることに気づいたので、 `blank?` で判定するようにしました。
2. タスクをタイトルとステータスで検索するフォームを作成しました
3. タスク一覧にステータスを表示するように
4. タスクを検索するという文言のi18nデータを追加

### レビュアー

@june29 , 誰でも