### PR TITLE
タスクモデルのステータスにインデックスを貼った

### DIFF
--- a/db/migrate/20180710154008_add_index_to_status_column_of_tasks.rb
+++ b/db/migrate/20180710154008_add_index_to_status_column_of_tasks.rb
@@ -1,0 +1,5 @@
+class AddIndexToStatusColumnOfTasks < ActiveRecord::Migration[5.2]
+  def change
+    add_index :tasks, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_04_023918) do
+ActiveRecord::Schema.define(version: 2018_07_10_154008) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 2018_07_04_023918) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "status", default: 0
+    t.index ["status"], name: "index_tasks_on_status"
     t.index ["title", "description", "priority"], name: "index_tasks_on_title_and_description_and_priority"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,10 +1,6 @@
 require 'faker'
 
-# Index が効いているか確認するために
-# めちゃくちゃな量を登録している
-# 確認が終わったら削除する
-
-100000.times do |i|
+10.times do |i|
   created_at = Faker::Time.forward.to_datetime
   expire_at = created_at + 2.days
   Task.create(

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,12 +1,43 @@
 require 'faker'
 
-10.times do |i|
+# Index が効いているか確認するために
+# めちゃくちゃな量を登録している
+# 確認が終わったら削除する
+
+30000.times do |i|
   created_at = Faker::Time.forward.to_datetime
   expire_at = created_at + 2.days
   Task.create(
     title:    "タスク#{i}",
     description:  "内容#{i}",
     priority: 1,
+    status: 0,
+    expire_at: expire_at,
+    created_at: created_at
+  )
+end
+
+30000.times do |i|
+  created_at = Faker::Time.forward.to_datetime
+  expire_at = created_at + 2.days
+  Task.create(
+    title:    "タスク#{i}",
+    description:  "内容#{i}",
+    priority: 1,
+    status: 1,
+    expire_at: expire_at,
+    created_at: created_at
+  )
+end
+
+30000.times do |i|
+  created_at = Faker::Time.forward.to_datetime
+  expire_at = created_at + 2.days
+  Task.create(
+    title:    "タスク#{i}",
+    description:  "内容#{i}",
+    priority: 1,
+    status: 2,
     expire_at: expire_at,
     created_at: created_at
   )

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,40 +4,14 @@ require 'faker'
 # めちゃくちゃな量を登録している
 # 確認が終わったら削除する
 
-30000.times do |i|
+100000.times do |i|
   created_at = Faker::Time.forward.to_datetime
   expire_at = created_at + 2.days
   Task.create(
     title:    "タスク#{i}",
     description:  "内容#{i}",
     priority: 1,
-    status: 0,
-    expire_at: expire_at,
-    created_at: created_at
-  )
-end
-
-30000.times do |i|
-  created_at = Faker::Time.forward.to_datetime
-  expire_at = created_at + 2.days
-  Task.create(
-    title:    "タスク#{i}",
-    description:  "内容#{i}",
-    priority: 1,
-    status: 1,
-    expire_at: expire_at,
-    created_at: created_at
-  )
-end
-
-30000.times do |i|
-  created_at = Faker::Time.forward.to_datetime
-  expire_at = created_at + 2.days
-  Task.create(
-    title:    "タスク#{i}",
-    description:  "内容#{i}",
-    priority: 1,
-    status: 2,
+    status: Faker::Number.between(0, 2),
     expire_at: expire_at,
     created_at: created_at
   )


### PR DESCRIPTION
### 概要

タスクモデルのステータスにインデックスを貼りました。  
これでステータスを使った検索が高速になりました。

### 証跡

ステータスが `todo`, `doing`, `done` なものをそれぞれ30000個作成してステータスで検索を行った。

#### Indexなし

```
Task Load (158.8ms)  SELECT "tasks".* FROM "tasks" WHERE "tasks"."status" = $1 ORDER BY "tasks"."created_at" DESC  [["status", "0"]]
```

##### 実行計画

```
Sort  (cost=4464.23..4539.12 rows=29955 width=65)
  Sort Key: created_at DESC
  ->  Seq Scan on tasks  (cost=0.00..2237.00 rows=29955 width=65)
        Filter: (status = 0)
(4 rows)
```

#### Indexあり

```
Task Load (68.1ms)  SELECT "tasks".* FROM "tasks" WHERE "tasks"."status" = $1 ORDER BY "tasks"."created_at" DESC  [["status", "0"]]
```

##### 実行計画

```
Sort  (cost=3457.74..3532.62 rows=29955 width=65)
  Sort Key: created_at DESC
  ->  Index Scan using index_tasks_on_status on tasks  (cost=0.29..1230.51 rows=29955 width=65)
        Index Cond: (status = 0)
(4 rows)
```

#### 結果

- **158.8ms → 68.1ms**
- コストも `4464.23..4539.12` → `3457.74..3532.62` となった

### 補足

- 実験のときにデータ(seed)の内容によっては `INDEX SCAN` ではなく `Bitmap Heap Scan` となって「ほー」となったのでメモ
  - https://git.pepabo.com/gist/mrtc0/1515f7d8ab6a55c9e583ac56e4449b09

### レビュアー

@june29 , 誰でも

### 資料

- https://github.com/everyleaf/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9715-%E3%82%B9%E3%83%86%E3%83%BC%E3%82%BF%E3%82%B9%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%81%A6%E6%A4%9C%E7%B4%A2%E3%81%A7%E3%81%8D%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%97%E3%82%88%E3%81%86