### PR TITLE
Taskモデルの priority を enum で定義した

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -9,6 +9,7 @@ class TasksController < ApplicationController
 
   def new
     @task = Task.new
+    @priorities = Task.priorities
   end
 
   def create
@@ -29,6 +30,7 @@ class TasksController < ApplicationController
 
   def edit
     @statuses = Task.statuses
+    @priorities = Task.priorities
   end
 
   def update

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,21 +1,15 @@
 class Task < ApplicationRecord
   enum status: { todo: 0, doing: 1, done: 2 }
+  enum priority: { non: 0, low: 1, meddium: 2, high: 3 }
 
   validates :title,
     presence: { message: I18n.t('view.task.message.error.required') }
-
-  validates :priority,
-    numericality: { only_integer: true }, unless: :priority_is_nil?
 
   validate :expire_greater_than_current_time
 
   scope :filter_by_title, ->(title) { where('title like ?', "%#{title}%") unless title.blank? }
   scope :filter_by_status, ->(status) { where(status: status) unless status.blank? }
   scope :sort_by_expire, ->(sort) { sort == 'expire' ? order(expire_at: 'ASC') : order(created_at: 'DESC') }
-
-  def priority_is_nil?
-    priority.nil?
-  end
 
   def expire_greater_than_current_time
     return if expire_at.nil?

--- a/app/views/tasks/_edit_form.erb
+++ b/app/views/tasks/_edit_form.erb
@@ -26,7 +26,7 @@
 
   <div class="field">
     <%= form.label :priority %>
-    <%= form.text_field :priority %>
+    <%= form.select :priority, priorities.keys.to_a %>
   </div>
 
   <div class="field">

--- a/app/views/tasks/_new_form.erb
+++ b/app/views/tasks/_new_form.erb
@@ -26,7 +26,7 @@
 
   <div class="field">
     <%= form.label :priority %>
-    <%= form.text_field :priority %>
+    <%= form.select :priority, priorities.keys.to_a %>
   </div>
 
   <div class="actions">

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,2 +1,2 @@
-<%= render 'edit_form', task: @task, statuses: @statuses %>
+<%= render 'edit_form', task: @task, statuses: @statuses, priorities: @priorities %>
 

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,4 +1,4 @@
 <h1><%= t('view.task.title.new') %></h1>
 
-<%= render 'new_form', task: @task %>
+<%= render 'new_form', task: @task, priorities: @priorities %>
 <%= link_to t('view.common.link_text.back'), tasks_path %>

--- a/db/migrate/20180711062207_priority_migrate_to_enum.rb
+++ b/db/migrate/20180711062207_priority_migrate_to_enum.rb
@@ -1,0 +1,5 @@
+class PriorityMigrateToEnum < ActiveRecord::Migration[5.2]
+  def change
+    change_column_default :tasks, :priority, 0
+  end
+end

--- a/db/migrate/20180711073021_priority_is_not_null.rb
+++ b/db/migrate/20180711073021_priority_is_not_null.rb
@@ -1,0 +1,5 @@
+class PriorityIsNotNull < ActiveRecord::Migration[5.2]
+  def change
+    change_column :tasks, :priority, :integer, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_10_154008) do
+ActiveRecord::Schema.define(version: 2018_07_11_073021) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,7 +18,7 @@ ActiveRecord::Schema.define(version: 2018_07_10_154008) do
   create_table "tasks", force: :cascade do |t|
     t.string "title", null: false
     t.text "description"
-    t.integer "priority"
+    t.integer "priority", default: 0, null: false
     t.datetime "expire_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -21,13 +21,6 @@ FactoryBot.define do
       description 'これはタイトルがないタスクです'
     end
 
-    factory :priority_is_not_integer_task do
-      title 'タスク1'
-      description 'これは優先度が数値ではないタスクです'
-      expire_at { Faker::Time.forward.to_datetime }
-      priority 'wei'
-    end
-
     factory :priority_is_nil_task do
       title 'タスク1'
       description 'これは優先度がnilなタスクです'

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -12,7 +12,7 @@ describe 'Task' do
     fill_in 'Title', with: 'タスク1'
     fill_in 'Description', with: 'これはテスト用のタスクです'
     fill_in 'Expire at', with: '2019-01-01 00:00:00'
-    fill_in 'Priority', with: '1'
+    select 'meddium', from: 'Priority'
     find(:xpath, '/html[1]/body[1]/form[1]/div[@class="actions"]/input[1]').click
     expect(page).to have_content I18n.t('view.task.message.created')
     expect(Task.exists?(title: 'タスク1')).to be_truthy
@@ -44,7 +44,7 @@ describe 'Task' do
     fill_in 'Title', with: 'non-expire-task'
     fill_in 'Description', with: 'これは期限が設定されていないタスクです'
     fill_in 'Expire at', with: ''
-    fill_in 'Priority', with: '1'
+    select 'meddium', from: 'Priority'
     find(:xpath, '/html[1]/body[1]/form[1]/div[@class="actions"]/input[1]').click
     expect(page).to have_content I18n.t('view.task.message.created')
     expect(Task.exists?(title: 'non-expire-task')).to be_truthy

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -19,17 +19,6 @@ describe Task, type: :model do
       expect(task.errors.size).to eq(1)
     end
 
-    it '優先度が数字じゃない場合は作成できないこと' do
-      task = build(:priority_is_not_integer_task)
-      task.valid?
-      expect(task.errors[:priority].size).to eq(1)
-    end
-
-    it '優先度がnilのときは作成できること' do
-      task = build(:priority_is_nil_task)
-      expect(task).to be_valid
-    end
-
     it 'ステータスがデフォルトで未着手であること' do
       task = build(:task)
       expect(task.status).to eq('todo')


### PR DESCRIPTION
### 概要

Taskモデルで優先度を表す priority は「高」「中」「低」の3種類なので、`enum` で定義することにしました。  
また、「高」「中」「低」に当てはまらないけど、とりあえず todo として書いておきたいということもあると思うので「無」を追加しました。

- `高` → `high`
- `中` → `middle` 
- `低` → `low`
- `無` → `non`

`non` は `none` が ActiveRecord に取られていたので `non` にしました。
データベースで `NOT NULL` を追加したので `nil` かどうかを確認するメソッドなどを削除しています。
### レビュアー

@june29 , 誰でも