### PR TITLE
タスクを優先順位でソートできるようにした

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,9 +1,10 @@
 # タスクの一覧、作成、更新、削除
 class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
+  before_action :set_priority, only: [:index]
 
   def index
-    @tasks = Task.filter_by_title_and_status(params)
+    @tasks = @current_tasks.filter_by_title_and_status(params)
     @statuses = Task.statuses
   end
 
@@ -60,5 +61,14 @@ class TasksController < ApplicationController
 
     def task_params
       params.require(:task).permit(:title, :description, :expire_at, :priority)
+    end
+
+    def set_priority
+      case
+      when params[:priority]
+        @current_tasks = Task.sort_by_priority(params[:priority])
+      else
+        @current_tasks = Task.all
+      end
     end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -64,8 +64,7 @@ class TasksController < ApplicationController
     end
 
     def set_priority
-      case
-      when params[:priority]
+      if params[:priority]
         @current_tasks = Task.sort_by_priority(params[:priority])
       else
         @current_tasks = Task.all

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -11,6 +11,8 @@ class Task < ApplicationRecord
   scope :filter_by_status, ->(status) { where(status: status) unless status.blank? }
   scope :sort_by_expire, ->(sort) { sort == 'expire' ? order(expire_at: 'ASC') : order(created_at: 'DESC') }
 
+  scope :sort_by_priority, ->(priority) { priority == 'high' ? order(priority: 'DESC') : order(priority: 'ASC') }
+
   def expire_greater_than_current_time
     return if expire_at.nil?
 
@@ -24,4 +26,5 @@ class Task < ApplicationRecord
       .filter_by_status(params[:status])
       .sort_by_expire(params[:sort])
   end
+
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -11,7 +11,7 @@ class Task < ApplicationRecord
   scope :filter_by_status, ->(status) { where(status: status) unless status.blank? }
   scope :sort_by_expire, ->(sort) { sort == 'expire' ? order(expire_at: 'ASC') : order(created_at: 'DESC') }
 
-  scope :sort_by_priority, ->(priority) { priority == 'high' ? order(priority: 'DESC') : order(priority: 'ASC') }
+  scope :sort_by_priority, ->(priority) { priority == 'desc' ? order(priority: 'DESC') : order(priority: 'ASC') }
 
   def expire_greater_than_current_time
     return if expire_at.nil?
@@ -26,5 +26,4 @@ class Task < ApplicationRecord
       .filter_by_status(params[:status])
       .sort_by_expire(params[:sort])
   end
-
 end

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -9,6 +9,7 @@
     <tr>
       <th>タスク</th>
       <th>ステータス</th>
+      <th>優先度</th>
       <th>作成日時</th>
       <th>期限</th>
       <th>詳細</th>
@@ -20,6 +21,7 @@
       <tr>
         <td id="title"><%= task.title %></td>
         <td id="status"><%= task.status %></td>
+        <td id="priority"><%= task.priority %></td>
         <td id="created_at"><%= l(task.created_at, format: :long) %></td>
         <td id="expire_at"><%= l(task.expire_at, format: :long) unless task.expire_at.nil? %></td>
         <td id="edit_link"><%= link_to t('view.common.link_text.edit'), edit_task_path(task) %></td>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,5 +1,7 @@
 <%= link_to t('view.task.link_text.sort_by_expire'), tasks_path(sort: 'expire'), id: "sort_by_expire"  %> | 
 <%= link_to t('view.task.link_text.sort_by_created_at'), tasks_path, id: "sort_by_created_at" %>
+<%= link_to t('view.task.link_text.sort_by_priority_desc'), tasks_path(priority: 'desc'), id: "sort_by_priority" %>
+<%= link_to t('view.task.link_text.sort_by_priority_asc'), tasks_path(priority: 'asc'), id: "sort_by_asc" %>
 
 <%= render 'search_form', statuses: @statuses %>
 

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,7 +1,7 @@
 <%= link_to t('view.task.link_text.sort_by_expire'), tasks_path(sort: 'expire'), id: "sort_by_expire"  %> | 
 <%= link_to t('view.task.link_text.sort_by_created_at'), tasks_path, id: "sort_by_created_at" %>
-<%= link_to t('view.task.link_text.sort_by_priority_desc'), tasks_path(priority: 'desc'), id: "sort_by_priority" %>
-<%= link_to t('view.task.link_text.sort_by_priority_asc'), tasks_path(priority: 'asc'), id: "sort_by_asc" %>
+<%= link_to t('view.task.link_text.sort_by_priority_desc'), tasks_path(priority: 'desc'), id: "sort_by_priority_desc" %>
+<%= link_to t('view.task.link_text.sort_by_priority_asc'), tasks_path(priority: 'asc'), id: "sort_by_priority_asc" %>
 
 <%= render 'search_form', statuses: @statuses %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,6 +15,8 @@ en:
       link_text:
         sort_by_expire: "Sort by due date"
         sort_by_created_at: "Sort by new created date"
+        sort_by_priority_desc: "Sort by high of priority"
+        sort_by_priority_asc: "Sort by low of priority"
     common:
       button_text:
         create: "Create"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -15,8 +15,8 @@ ja:
       link_text:
         sort_by_expire: "終了期限が近い順"
         sort_by_created_at: "作成日時が新しい順"
-        sort_by_priority_desc: "優先順位が高い順"
-        sort_by_priority_asc: "優先順位が低い順"
+        sort_by_priority_desc: "優先度が高い順"
+        sort_by_priority_asc: "優先度が低い順"
     common:
       button_text:
         create: "作成する"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -15,6 +15,8 @@ ja:
       link_text:
         sort_by_expire: "終了期限が近い順"
         sort_by_created_at: "作成日時が新しい順"
+        sort_by_priority_desc: "優先順位が高い順"
+        sort_by_priority_asc: "優先順位が低い順"
     common:
       button_text:
         create: "作成する"

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -39,5 +39,11 @@ FactoryBot.define do
       description 'これはstatusがdoneなタスクです'
       priority 1
     end
+
+    factory :priority_is_random_task do
+      title '優先度ランダムタスク'
+      description 'これは優先度がランダムに設定されるタスクです'
+      priority Faker::Number.between(0, 3)
+    end
   end
 end

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -43,7 +43,7 @@ FactoryBot.define do
     factory :priority_is_random_task do
       title '優先度ランダムタスク'
       description 'これは優先度がランダムに設定されるタスクです'
-      priority Faker::Number.between(0, 3)
+      priority { Faker::Number.between(0, 3) }
     end
   end
 end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -87,4 +87,24 @@ describe 'Task' do
     expect_task = Task.filter_by_title('task').filter_by_status('doing')
     expect(page.all('tbody tr').count).to eq(expect_task.count)
   end
+
+  example '優先順位が高い順でソートされること' do
+    create_list(:priority_is_random_task, 10)
+    visit tasks_path
+    click_link('sort_by_priority_desc')
+    @expire_priorities = page.all('#priority').map(&:text)
+    # ここでDESCじゃないので失敗する
+    @expect_priorities = Task.order(priority: 'ASC').map(&:priority)
+    expect(@expire_priorities).to eq(@expect_priorities)
+  end
+
+  example '優先順位が低い順でソートされること' do
+    create_list(:priority_is_random_task, 10)
+    visit tasks_path
+    click_link('sort_by_priority_asc')
+    @expire_priorities = page.all('#priority').map(&:text)
+    # ここでASCじゃないので失敗する
+    @expect_priorities = Task.order(priority: 'DESC').map(&:priority)
+    expect(@expire_priorities).to eq(@expect_priorities)
+  end
 end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -88,7 +88,7 @@ describe 'Task' do
     expect(page.all('tbody tr').count).to eq(expect_task.count)
   end
 
-  example '優先順位が高い順でソートされること' do
+  example '優先度が高い順でソートされること' do
     create_list(:priority_is_random_task, 10)
     visit tasks_path
     click_link('sort_by_priority_desc')
@@ -97,7 +97,7 @@ describe 'Task' do
     expect(@expire_priorities).to eq(@expect_priorities)
   end
 
-  example '優先順位が低い順でソートされること' do
+  example '優先度が低い順でソートされること' do
     create_list(:priority_is_random_task, 10)
     visit tasks_path
     click_link('sort_by_priority_asc')

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -93,8 +93,7 @@ describe 'Task' do
     visit tasks_path
     click_link('sort_by_priority_desc')
     @expire_priorities = page.all('#priority').map(&:text)
-    # ここでDESCじゃないので失敗する
-    @expect_priorities = Task.order(priority: 'ASC').map(&:priority)
+    @expect_priorities = Task.order(priority: 'DESC').map(&:priority)
     expect(@expire_priorities).to eq(@expect_priorities)
   end
 
@@ -103,8 +102,7 @@ describe 'Task' do
     visit tasks_path
     click_link('sort_by_priority_asc')
     @expire_priorities = page.all('#priority').map(&:text)
-    # ここでASCじゃないので失敗する
-    @expect_priorities = Task.order(priority: 'DESC').map(&:priority)
+    @expect_priorities = Task.order(priority: 'ASC').map(&:priority)
     expect(@expire_priorities).to eq(@expect_priorities)
   end
 end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -92,17 +92,17 @@ describe 'Task' do
     create_list(:priority_is_random_task, 10)
     visit tasks_path
     click_link('sort_by_priority_desc')
-    @expire_priorities = page.all('#priority').map(&:text)
+    @priorities = page.all('#priority').map(&:text)
     @expect_priorities = Task.order(priority: 'DESC').map(&:priority)
-    expect(@expire_priorities).to eq(@expect_priorities)
+    expect(@priorities).to eq(@expect_priorities)
   end
 
   example '優先度が低い順でソートされること' do
     create_list(:priority_is_random_task, 10)
     visit tasks_path
     click_link('sort_by_priority_asc')
-    @expire_priorities = page.all('#priority').map(&:text)
+    @priorities = page.all('#priority').map(&:text)
     @expect_priorities = Task.order(priority: 'ASC').map(&:priority)
-    expect(@expire_priorities).to eq(@expect_priorities)
+    expect(@priorities).to eq(@expect_priorities)
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -78,4 +78,16 @@ describe Task, type: :model do
     params = { title: '1', status: 'doing' }
     expect(Task.filter_by_title_and_status(params).count).to eq(0)
   end
+
+  it '優先順位が高い順で並び替えれること' do
+    params = { priority: 'desc' }
+    desc_priorities = Task.all.map { |task| task.priority }
+    expect(Task.sort_by_priority(params).map { |task| tasks.priority }).to eq(desc_priorities)
+  end
+
+  it '優先順位が低い順で並び替えれること' do
+    params = { priority: 'asc' }
+    desc_priorities = Task.all.map { |task| task.priority }
+    expect(Task.sort_by_priority(params).map { |task| tasks.priority }).to eq(desc_priorities.reverse)
+  end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -79,13 +79,13 @@ describe Task, type: :model do
     expect(Task.filter_by_title_and_status(params).count).to eq(0)
   end
 
-  it '優先順位が高い順で並び替えれること' do
+  it '優先度が高い順で並び替えれること' do
     params = { priority: 'desc' }
     desc_priorities = Task.all.map { |task| task.priority }
     expect(Task.sort_by_priority(params).map { |task| tasks.priority }).to eq(desc_priorities)
   end
 
-  it '優先順位が低い順で並び替えれること' do
+  it '優先度が低い順で並び替えれること' do
     params = { priority: 'asc' }
     desc_priorities = Task.all.map { |task| task.priority }
     expect(Task.sort_by_priority(params).map { |task| tasks.priority }).to eq(desc_priorities.reverse)


### PR DESCRIPTION
### 概要

タスクの優先度でソートできるようにしました。`DESC` を指定した場合は High ~ Non の順に、それ以外の場合は Non ~ High の順番でソートされます。

<img width="601" alt="2018-07-20 14 29 45" src="https://user-images.githubusercontent.com/5842353/42984816-6610623c-8c29-11e8-9d66-07723680af0a.png">

#### 補足

コントローラーに条件が増えて来てつらくなってきたので、今回のアクションは `before_action` で処理することにしました。  
`search_controller` として切り出すほうが良いのかなと思ったりしたのですが、もうこれ以上タスクをソートできる要素がないことから、今回の方針にしました。

### レビュアー

@june29 さん, 誰でも