### PR TITLE
kaminari でページネーションを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,8 @@ gem 'bootsnap', '>= 1.1.0', require: false
 
 gem 'http_accept_language'
 
+gem 'kaminari'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,18 @@ GEM
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    kaminari (1.1.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.1.1)
+      kaminari-activerecord (= 1.1.1)
+      kaminari-core (= 1.1.1)
+    kaminari-actionview (1.1.1)
+      actionview
+      kaminari-core (= 1.1.1)
+    kaminari-activerecord (1.1.1)
+      activerecord
+      kaminari-core (= 1.1.1)
+    kaminari-core (1.1.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -267,6 +279,7 @@ DEPENDENCIES
   faker
   http_accept_language
   jbuilder (~> 2.5)
+  kaminari
   listen (>= 3.0.5, < 3.2)
   pg
   pry-byebug

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -65,9 +65,9 @@ class TasksController < ApplicationController
 
     def set_priority
       if params[:priority]
-        @current_tasks = Task.sort_by_priority(params[:priority])
+        @current_tasks = Task.page(params[:page]).sort_by_priority(params[:priority])
       else
-        @current_tasks = Task.all
+        @current_tasks = Task.page(params[:page])
       end
     end
 end

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -6,6 +6,8 @@
 <%= render 'search_form', statuses: @statuses %>
 
 <hr />
+
+
 <table id="task_table">
   <thead>
     <tr>
@@ -34,4 +36,7 @@
     <% end %>
   </tbody>
 </table>
+
+<%= paginate @tasks %>
+
 <%= link_to t('view.common.link_text.new'), new_task_path %>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+Kaminari.configure do |config|
+  config.default_per_page = 10
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.params_on_first_page = false
+end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -231,3 +231,9 @@ ja:
       long: "%Y/%m/%d %H:%M"
       short: "%m/%d %H:%M"
     pm: 午後
+  views:
+    pagination:
+      first: "&laquo; 最初" # <<
+      last: "最後 &raquo;" # >>
+      previous: "&lsaquo; 前" # <
+      next: "次 &rsaquo;" # >

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,12 +1,12 @@
 require 'faker'
 
-10.times do |i|
+50.times do |i|
   created_at = Faker::Time.forward.to_datetime
   expire_at = created_at + 2.days
   Task.create(
     title:    "タスク#{i}",
     description:  "内容#{i}",
-    priority: 1,
+    priority: Faker::Number.between(0, 3),
     status: Faker::Number.between(0, 2),
     expire_at: expire_at,
     created_at: created_at

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -1,4 +1,7 @@
 require 'rails_helper'
+require 'kaminari'
+
+ITEM_PER_PAGE = Kaminari.config.default_per_page # kaminari の1ページあたりのアイテム数
 
 describe 'Task' do
   before do
@@ -93,7 +96,7 @@ describe 'Task' do
     visit tasks_path
     click_link('sort_by_priority_desc')
     @priorities = page.all('#priority').map(&:text)
-    @expect_priorities = Task.order(priority: 'DESC').map(&:priority)
+    @expect_priorities = Task.order(priority: 'DESC').limit(ITEM_PER_PAGE).map(&:priority)
     expect(@priorities).to eq(@expect_priorities)
   end
 
@@ -102,7 +105,15 @@ describe 'Task' do
     visit tasks_path
     click_link('sort_by_priority_asc')
     @priorities = page.all('#priority').map(&:text)
-    @expect_priorities = Task.order(priority: 'ASC').map(&:priority)
+    @expect_priorities = Task.order(priority: 'ASC').limit(ITEM_PER_PAGE).map(&:priority)
     expect(@priorities).to eq(@expect_priorities)
+  end
+
+  example 'ページネーションによってタスクが10個ずつ表示されていること' do
+    create_list(:task, 50)
+    visit tasks_path
+    expect(page.all('#task_table_body tr').size).to eq(ITEM_PER_PAGE)
+    click_link('2')
+    expect(page.all('#task_table_body tr').size).to eq(ITEM_PER_PAGE)
   end
 end


### PR DESCRIPTION
### 概要

kaminari でページネーションを追加しました。  
1ページあたり何件表示するみたいな要件はなかったので、とりあえず 10 個表示しています。

<img width="623" alt="2018-07-26 11 16 04" src="https://user-images.githubusercontent.com/5842353/43237634-a462bf4e-90c5-11e8-8cde-fd63d9abcbbf.png">
<img width="653" alt="2018-07-26 11 16 11" src="https://user-images.githubusercontent.com/5842353/43237637-a9699828-90c5-11e8-9164-f166d2a7d2cd.png">

ref : https://github.com/everyleaf/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9717-%E3%83%9A%E3%83%BC%E3%82%B8%E3%83%8D%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%82%88%E3%81%86

### レビュアー

@june29 さん、誰でも