### PR TITLE
Bootstarpを導入して、トップページをいい感じにした

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,9 @@ gem 'http_accept_language'
 
 gem 'kaminari'
 
+gem 'bootstrap', '~> 4.1.3'
+gem 'jquery-rails'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,11 +48,17 @@ GEM
       io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
+    autoprefixer-rails (9.0.0)
+      execjs
     bindex (0.5.0)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     bootsnap (1.3.0)
       msgpack (~> 1.0)
+    bootstrap (4.1.3)
+      autoprefixer-rails (>= 6.0.3)
+      popper_js (>= 1.12.9, < 2)
+      sass (>= 3.5.2)
     builder (3.2.3)
     byebug (10.0.2)
     capybara (3.2.1)
@@ -99,6 +105,10 @@ GEM
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    jquery-rails (4.3.3)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.1.1)
@@ -136,6 +146,7 @@ GEM
     parser (2.5.1.0)
       ast (~> 2.4.0)
     pg (1.0.0)
+    popper_js (1.14.3)
     powerpack (0.1.2)
     pry (0.11.3)
       coderay (~> 1.1.0)
@@ -271,6 +282,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.1.0)
+  bootstrap (~> 4.1.3)
   byebug
   capybara (>= 2.15, < 4.0)
   chromedriver-helper
@@ -279,6 +291,7 @@ DEPENDENCIES
   faker
   http_accept_language
   jbuilder (~> 2.5)
+  jquery-rails
   kaminari
   listen (>= 3.0.5, < 3.2)
   pg

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,4 +13,7 @@
 //= require rails-ujs
 //= require activestorage
 //= require turbolinks
+//= require jquery3
+//= require popper
+//= require bootstrap-sprockets
 //= require_tree .

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,3 +13,4 @@
  *= require_tree .
  *= require_self
  */
+@import "bootstrap";

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -1,0 +1,17 @@
+<nav class="navbar navbar-expand-lg navbar-light bg-light">
+  <a class="navbar-brand" href="#">TODO</a>
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarText" aria-controls="navbarText" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse" id="navbarText">
+    <ul class="navbar-nav mr-auto">
+      <li class="nav-item active">
+        <a class="nav-link" href="#">Home <span class="sr-only">(current)</span></a>
+      </li>
+    </ul>
+    <span class="navbar-text">
+      <!-- TODO: ここにログインリンクやユーザー名を出す -->
+    </span>
+  </div>
+</nav>
+

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,9 +10,12 @@
   </head>
 
   <body>
-    <% flash.each do |key, value| %>
-      <%= content_tag(:div, value, class: key) %>
-    <% end %>
-    <%= yield %>
+    <%= render 'navbar' %>
+    <div class="container">
+      <% flash.each do |key, value| %>
+        <%= content_tag(:div, value, class: key) %>
+      <% end %>
+      <%= yield %>
+    </div>
   </body>
 </html>

--- a/app/views/tasks/_search_form.erb
+++ b/app/views/tasks/_search_form.erb
@@ -1,5 +1,5 @@
-<%= form_tag(tasks_path, method: :get) do |f| %>
-  <%= text_field_tag :title %>
-  <%= select_tag :status, options_for_select(statuses), include_blank: true %>
-  <%= submit_tag t('view.common.button_text.search.') %>
+<%= form_tag(tasks_path, method: :get, class: "form-inline") do |f| %>
+  <%= text_field_tag :title, '',class: "form-control" %>
+  <%= select_tag :status, options_for_select(statuses), include_blank: true, class: "form-control" %>
+  <%= submit_tag t('view.common.button_text.search.'), class: "btn btn-dark" %>
 <% end %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,15 +1,16 @@
-<%= link_to t('view.task.link_text.sort_by_expire'), tasks_path(sort: 'expire'), id: "sort_by_expire"  %> | 
-<%= link_to t('view.task.link_text.sort_by_created_at'), tasks_path, id: "sort_by_created_at" %>
-<%= link_to t('view.task.link_text.sort_by_priority_desc'), tasks_path(priority: 'desc'), id: "sort_by_priority_desc" %>
-<%= link_to t('view.task.link_text.sort_by_priority_asc'), tasks_path(priority: 'asc'), id: "sort_by_priority_asc" %>
-
 <%= render 'search_form', statuses: @statuses %>
+
+<nav class="nav">
+  <%= link_to t('view.task.link_text.sort_by_expire'), tasks_path(sort: 'expire'), id: "sort_by_expire", class: "nav-link"  %>
+  <%= link_to t('view.task.link_text.sort_by_created_at'), tasks_path, id: "sort_by_created_at", class: "nav-link" %>
+  <%= link_to t('view.task.link_text.sort_by_priority_desc'), tasks_path(priority: 'desc'), id: "sort_by_priority_desc", class: "nav-link" %>
+  <%= link_to t('view.task.link_text.sort_by_priority_asc'), tasks_path(priority: 'asc'), id: "sort_by_priority_asc", class: "nav-link"%>
+</nav>
 
 <hr />
 
-
-<table id="task_table">
-  <thead>
+<table id="task_table" class="table">
+  <thead class="thead-dark">
     <tr>
       <th>タスク</th>
       <th>ステータス</th>

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -16,7 +16,7 @@ describe 'Task' do
     fill_in 'Description', with: 'これはテスト用のタスクです'
     fill_in 'Expire at', with: '2019-01-01 00:00:00'
     select 'meddium', from: 'Priority'
-    find(:xpath, '/html[1]/body[1]/form[1]/div[@class="actions"]/input[1]').click
+    find(:xpath, '/html[1]/body[1]/div[@class="container"]/form[1]/div[@class="actions"]/input[1]').click
     expect(page).to have_content I18n.t('view.task.message.created')
     expect(Task.exists?(title: 'タスク1')).to be_truthy
   end
@@ -25,7 +25,7 @@ describe 'Task' do
     visit edit_task_path(@task)
 
     fill_in 'Title', with: 'タスク-edited'
-    find(:xpath, '/html[1]/body[1]/form[1]/div[@class="actions"]/input[1]').click
+    find(:xpath, '/html[1]/body[1]/div[@class="container"]/form[1]/div[@class="actions"]/input[1]').click
     expect(page).to have_content I18n.t('view.task.message.updated')
     expect(Task.exists?(title: 'タスク-edited')).to eq(true)
   end
@@ -48,7 +48,7 @@ describe 'Task' do
     fill_in 'Description', with: 'これは期限が設定されていないタスクです'
     fill_in 'Expire at', with: ''
     select 'meddium', from: 'Priority'
-    find(:xpath, '/html[1]/body[1]/form[1]/div[@class="actions"]/input[1]').click
+    find(:xpath, '/html[1]/body[1]/div[@class="container"]/form[1]/div[@class="actions"]/input[1]').click
     expect(page).to have_content I18n.t('view.task.message.created')
     expect(Task.exists?(title: 'non-expire-task')).to be_truthy
     visit tasks_path
@@ -66,7 +66,7 @@ describe 'Task' do
   example 'タイトルで検索できること' do
     visit '/'
     fill_in 'title', with: 'タスク'
-    find(:xpath, '/html[1]/body[1]/form[1]/input[3]').click
+    find(:xpath, '/html[1]/body[1]/div[@class="container"]/form[1]/input[3]').click
     # %E3%82%BF%E3%82%B9%E3%82%AF1 = タスク
     visit '/tasks?title=%E3%82%BF%E3%82%B9%E3%82%AF1&status='
     expect(page.all('tbody tr').count).to eq(Task.where("title like '%タスク%'").count)
@@ -75,7 +75,7 @@ describe 'Task' do
   example 'ステータスで検索できること' do
     visit '/'
     select 'doing', from: 'status'
-    find(:xpath, '/html[1]/body[1]/form[1]/input[3]').click
+    find(:xpath, '/html[1]/body[1]/div[@class="container"]/form[1]/input[3]').click
     visit '/tasks?title=&status=1'
     expect(page.all('tbody tr').count).to eq(Task.doing.count)
   end
@@ -84,7 +84,7 @@ describe 'Task' do
     visit '/'
     fill_in 'title', with: 'task'
     select 'doing', from: 'status'
-    find(:xpath, '/html[1]/body[1]/form[1]/input[3]').click
+    find(:xpath, '/html[1]/body[1]/div[@class="container"]/form[1]/input[3]').click
     # タイトルが「task」を含み、かつ、doingであるものを検索
     visit '/tasks?title=task&status=1'
     expect_task = Task.filter_by_title('task').filter_by_status('doing')


### PR DESCRIPTION
### 概要

Bootstrap を導入して、まずはトップページをいい感じにしました。  

**Before**

<img width="623" alt="2018-07-26 11 16 04" src="https://user-images.githubusercontent.com/5842353/43258420-b9843b26-910d-11e8-9de8-857361cea448.png">

**After**

<img width="1679" alt="2018-07-26 16 58 23" src="https://user-images.githubusercontent.com/5842353/43258433-bf96d1e0-910d-11e8-8ba3-a3cd21163dd8.png">

ref: https://github.com/everyleaf/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9718-%E3%83%87%E3%82%B6%E3%82%A4%E3%83%B3%E3%82%92%E5%BD%93%E3%81%A6%E3%82%88%E3%81%86

### このPRでやらないこと

- トップページ意外のページにデザインを当てる
  - PRの粒度が大きくなると判断したのでやめました。別PRで当てていきます。
- kaminari のページネーション部分にデザインを当てる
  - kaminari のテンプレートを吐き出して当てるみたいな感じになりそうだったので、これも粒度が大きくなるのでやめました
- テストで要素を取ってくる `find` を `find_by_id` に変える
  - デザインが変わるたびにテストを修正するのは面倒なので、 `find_by_id` に変えて、id から取ってくるようにしたい。しかし、今回修正が必要だった箇所は `new` や `edit` 画面で、ここは追加でデザインを当てる画面なので、その際にテストも修正するという方針でいこうと思います。

### レビュアー

@june29 さん、誰でも

