### PR TITLE
時限爆弾があり、テストが失敗するのを修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   app:
     build: .
     ports:
-      - "3000:3000"
+      - "9000:3000"
     environment:
       - "DATABASE_HOST=db"
       - "DATABASE_PORT=5432"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   app:
     build: .
     ports:
-      - "9000:3000"
+      - "3000:3000"
     environment:
       - "DATABASE_HOST=db"
       - "DATABASE_PORT=5432"

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -14,7 +14,7 @@ describe 'Task' do
     visit new_task_path
     fill_in 'Title', with: 'タスク'
     fill_in 'Description', with: 'これはテスト用のタスクです'
-    fill_in 'expire_at', with: '2018-07-31 02:05'
+    fill_in 'expire_at', with: '2050-07-31 02:05'
     select 'meddium', from: 'Priority'
     find_by_id('submit').click
     expect(page).to have_content I18n.t('view.task.message.created')

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 require 'kaminari'
+require 'faker'
 
 ITEM_PER_PAGE = Kaminari.config.default_per_page # kaminari の1ページあたりのアイテム数
 
@@ -14,7 +15,7 @@ describe 'Task' do
     visit new_task_path
     fill_in 'Title', with: 'タスク'
     fill_in 'Description', with: 'これはテスト用のタスクです'
-    fill_in 'expire_at', with: '2050-07-31 02:05'
+    fill_in 'expire_at', with: Faker::Time.forward.to_datetime
     select 'meddium', from: 'Priority'
     find_by_id('submit').click
     expect(page).to have_content I18n.t('view.task.message.created')
@@ -46,7 +47,7 @@ describe 'Task' do
     visit new_task_path
     fill_in 'Title', with: 'non-expire-task'
     fill_in 'Description', with: 'これは期限が設定されていないタスクです'
-    fill_in 'expire_at', with: '2030-01-01 01:00'
+    fill_in 'expire_at', with: Faker::Time.forward.to_datetime
     select 'meddium', from: 'Priority'
     find_by_id('submit').click
 


### PR DESCRIPTION
タスクの期限を過去の時間で作成している箇所があり、つい最近、時限爆弾が爆発したので解除しました。

###  レビュアー

@june29 さん, 誰でも