### PR TITLE
タスク編集ページのデザインを変更

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -18,7 +18,7 @@ class TasksController < ApplicationController
 
     respond_to do |format|
       if @task.save
-        format.html { redirect_to @task, flash: { success: t('view.task.message.created') } }
+        format.html { redirect_to tasks_path, flash: { success: t('view.task.message.created') } }
       else
         # TODO: エラー処理を書く
         @priorities = Task.priorities
@@ -38,7 +38,7 @@ class TasksController < ApplicationController
   def update
     respond_to do |format|
       if @task.update(task_params)
-        format.html { redirect_to @task, flash: { success: t('view.task.message.updated') } }
+        format.html { redirect_to tasks_path, flash: { success: t('view.task.message.updated') } }
       else
         # TODO: エラー処理を書く
         format.html { render :edit }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
     <%= render 'navbar' %>
     <div class="container">
       <% flash.each do |key, value| %>
-        <%= content_tag(:div, value, class: key) %>
+        <%= content_tag(:div, value, class: "alert alert-success") %>
       <% end %>
       <%= yield %>
     </div>

--- a/app/views/tasks/_edit_form.erb
+++ b/app/views/tasks/_edit_form.erb
@@ -1,40 +1,49 @@
-<%= form_with(model: task, local: true) do |form| %>
-  <% if task.errors.any? %>
-    <div id="error-message">
-      <ul>
-      <% task.errors.full_messages.each do |msg| %>
-        <li><%= msg %></li>
+<div class="row justify-content-center">
+  <div class="col-6">
+    <%= form_with(model: task, local: true) do |form| %>
+      <% if task.errors.any? %>
+        <div id="error-message" class="alert alert-danger" role="alert">
+          <ul>
+            <% task.errors.full_messages.each do |msg| %>
+              <li><%= msg %></li>
+            <% end %>
+          </ul>
+        </div>
       <% end %>
-      </ul>
-    </div>
-  <% end %>
 
-  <div class="field">
-    <%= form.label :title %>
-    <%= form.text_field :title %>
-  </div>
+      <div class="form-group">
+        <%= form.label :title %>
+        <%= form.text_field :title, class: "form-control", required: "true" %>
+      </div>
 
-  <div class="field">
-    <%= form.label :description %>
-    <%= form.text_field :description %>
-  </div>
+      <div class="form-group">
+        <%= form.label :description %>
+        <%= form.text_field :description, class: "form-control" %>
+      </div>
 
-  <div class="field">
-    <%= form.label :expire_at %>
-    <%= form.text_field :expire_at %>
-  </div>
+      <div class="from-group">
+        <%= form.label :expire_at %>
+        <%= form.text_field :expire_at, id: "expire_at", :autocomplete => :off, class: "form-control" %>
+      </div>
 
-  <div class="field">
-    <%= form.label :priority %>
-    <%= form.select :priority, priorities.keys.to_a %>
-  </div>
+      <div class="form-group">
+        <%= form.label :priority %>
+        <%= form.select :priority, priorities.keys.to_a, {}, {class: "form-control"} %>
+      </div>
 
-  <div class="field">
-    <%= form.label :status %>
-    <%= form.select :status, statuses.keys.to_a %>
-  </div>
+      <div class="form-group">
+        <%= form.label :status %>
+        <%= form.select :status, statuses.keys.to_a, {}, {class: "form-control"} %>
+      </div>
 
-  <div class="actions">
-    <%= form.submit %>
+      <div class="row justify-content-center">
+        <div class="mx-auto">
+          <div class="form-group">
+            <%= link_to t('view.common.link_text.back'), tasks_path, class: "btn btn-dark" %>
+            <%= form.submit id: "submit", class: "btn btn-primary" %>
+          </div>
+        </div>
+      </div>
+    <% end %>
   </div>
-<% end %>
+</div>

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,2 +1,5 @@
+<div class="row justify-content-center">
+  <h1><%= t('view.task.title.edit') %></h1>
+</div>
 <%= render 'edit_form', task: @task, statuses: @statuses, priorities: @priorities %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,7 @@ en:
           expire_greater_than_current_time: "The expire can not be set to the past time"
       title:
         new: "Create new task"
+        edit: "Edit task"
       link_text:
         sort_by_expire: "Sort by due date"
         sort_by_created_at: "Sort by new created date"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -12,6 +12,7 @@ ja:
           expire_greater_than_current_time: "期限を過去の時間に設定することはできません"
       title:
         new: "タスクの新規作成"
+        edit: "タスクの編集"
       link_text:
         sort_by_expire: "終了期限が近い順"
         sort_by_created_at: "作成日時が新しい順"

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -26,7 +26,7 @@ describe 'Task' do
     visit edit_task_path(@task)
 
     fill_in 'Title', with: 'タスク-edited'
-    find(:xpath, '/html[1]/body[1]/div[@class="container"]/form[1]/div[@class="actions"]/input[1]').click
+    find_by_id('submit').click
     expect(page).to have_content I18n.t('view.task.message.updated')
     expect(Task.exists?(title: 'タスク-edited')).to eq(true)
   end


### PR DESCRIPTION
### 概要

- タスクの編集ページのデザインを変更
- タスクの作成 / 編集後のリダイレクト先をタスク一覧に

<img width="1680" alt="2018-08-08 12 59 49" src="https://user-images.githubusercontent.com/5842353/43815515-fef56714-9b0a-11e8-9ae0-8ecc95275440.png">

タスクの作成 / 編集後にタスク詳細ページにリダイレクトされるのは不要だと思ったのでやめた。
理由はタスク一覧ページにそのタスクの情報が表示されているから。

### レビュアー

@june29 さん、誰でも