### PR TITLE
ログアウトやサインアップなどのリンクを追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   include Session
+  include SessionHelper
 
   before_action :set_locale
   before_action :require_logged_in!

--- a/app/controllers/concerns/session.rb
+++ b/app/controllers/concerns/session.rb
@@ -11,14 +11,6 @@ module Session
     @current_user = nil
   end
 
-  def logged_in?
-    !current_user.nil?
-  end
-
-  def current_user
-    @current_user ||= User.find_by(id: session[:user_id])
-  end
-
   def require_logged_in!
     redirect_to login_path unless logged_in?
   end

--- a/app/helpers/session_helper.rb
+++ b/app/helpers/session_helper.rb
@@ -1,5 +1,9 @@
 module SessionHelper
   def logged_in?
-    !@current_user.nil?
+    !current_user.nil?
+  end
+
+  def current_user
+    @current_user ||= User.find_by(id: session[:user_id])
   end
 end

--- a/app/helpers/session_helper.rb
+++ b/app/helpers/session_helper.rb
@@ -1,2 +1,5 @@
 module SessionHelper
+  def logged_in?
+    !@current_user.nil?
+  end
 end

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -9,7 +9,7 @@
         <a class="nav-link" href="#">Home <span class="sr-only">(current)</span></a>
       </li>
     </ul>
-    <% if @current_user %>
+    <% if logged_in? %>
     <span class="navbar-text mr-sm-2">
       <%= @current_user.email %>
     </span>

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -14,14 +14,14 @@
       <%= @current_user.email %>
     </span>
     <span class="mr-sm-2">
-      <%= link_to t('view.session.link_text.logout'), logout_path, method: :delete %>
+      <%= link_to t('view.session.link_text.logout'), logout_path, method: :delete, id: 'logout-link' %>
     </span>
     <% else %>
     <span class="mr-sm-2">
-      <%= link_to t('view.session.link_text.signup'), signup_path %>
+      <%= link_to t('view.session.link_text.signup'), signup_path, id: 'signup-link' %>
     </span>
     <span class="mr-sm-2">
-      <%= link_to t('view.session.link_text.login'), login_path %>
+      <%= link_to t('view.session.link_text.login'), login_path, id: 'login-link' %>
     </span>
     <% end %>
   </div>

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -9,9 +9,21 @@
         <a class="nav-link" href="#">Home <span class="sr-only">(current)</span></a>
       </li>
     </ul>
-    <span class="navbar-text">
-      <!-- TODO: ここにログインリンクやユーザー名を出す -->
+    <% if @current_user %>
+    <span class="navbar-text mr-sm-2">
+      <%= @current_user.email %>
     </span>
+    <span class="mr-sm-2">
+      <%= link_to t('view.session.link_text.logout'), logout_path, method: :delete %>
+    </span>
+    <% else %>
+    <span class="mr-sm-2">
+      <%= link_to t('view.session.link_text.signup'), signup_path %>
+    </span>
+    <span class="mr-sm-2">
+      <%= link_to t('view.session.link_text.login'), login_path %>
+    </span>
+    <% end %>
   </div>
 </nav>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,7 +11,7 @@ en:
         login_failed: "Invalid email or password"
       link_text:
         login: "Login"
-        singup: "Signup"
+        singup: "Sign up"
         logout: "Logout"
     task:
       message:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,6 +9,10 @@ en:
       message:
         login_successful: "Login Successful"
         login_failed: "Invalid email or password"
+      link_text:
+        login: "Login"
+        singup: "Signup"
+        logout: "Logout"
     task:
       message:
         created: "Created a new task"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -9,6 +9,10 @@ ja:
       message:
         login_successful: "ログインしました"
         login_failed: "ユーザー名かパスワードが違います"
+      link_text:
+        login: "ログイン"
+        signup: "登録"
+        logout: "ログアウト"
     task:
       message:
         created: "タスクを作成しました"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,6 @@ Rails.application.routes.draw do
 
   # Logout
   delete 'logout', to: 'session#destroy'
-  root to: 'tasks#index'
 
   # Task
   resources :tasks

--- a/spec/features/session_spec.rb
+++ b/spec/features/session_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe 'Session' do
+  let(:user1) { create(:user1) }
+
+  example 'ログインできること' do
+    visit login_path
+    fill_in 'user_email', with: user1.email
+    fill_in 'user_password', with: 'Password1234'
+    find_by_id('login').click
+
+    expect(page).to have_content I18n.t('view.session.message.login_successful')
+  end
+
+  example 'ログアウトできること' do
+    visit login_path
+    fill_in 'user_email', with: user1.email
+    fill_in 'user_password', with: 'Password1234'
+    find_by_id('login').click
+
+    find_by_id('logout-link').click
+    visit tasks_path
+    expect(current_path).to eq(login_path)
+  end
+end


### PR DESCRIPTION
### 概要

NavBar に以下を表示するようにしました

- 未ログイン時
  - signup, login へのリンク
- ログイン時
  - メールアドレス, ログアウトへのリンク

### その他

`root to: 'tasks#index'` が重複していたのでエイッと消しました。

### レビュアー

@june29 さん、誰でも