### PR TITLE
Task モデルの user_id にインデックスを貼った

### DIFF
--- a/db/migrate/20180911053552_add_index_to_user_id_column_of_task.rb
+++ b/db/migrate/20180911053552_add_index_to_user_id_column_of_task.rb
@@ -1,0 +1,5 @@
+class AddIndexToUserIdColumnOfTask < ActiveRecord::Migration[5.2]
+  def change
+    add_index :tasks, :user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_20_053636) do
+ActiveRecord::Schema.define(version: 2018_09_11_053552) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 2018_08_20_053636) do
     t.integer "user_id"
     t.index ["status"], name: "index_tasks_on_status"
     t.index ["title", "description", "priority"], name: "index_tasks_on_title_and_description_and_priority"
+    t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
### 概要

user_id を条件に Task を検索するときに、高速に検索できるように user_id にインデックスを貼りました。

いずれも5000件の seed を投入して確認しました。

#### 貼る前

`1.6ms`

```ruby
[1] pry(main)> Task.where(user_id: 123)
=>   Task Load (1.6ms)  SELECT "tasks".* FROM "tasks" WHERE "tasks"."user_id" = $1  [["user_id", 123]]
```

#### 貼った後

`0.6ms`

```ruby
[1] pry(main)> Task.where(user_id: 123)
=>   Task Load (0.6ms)  SELECT "tasks".* FROM "tasks" WHERE "tasks"."user_id" = $1  [["user_id", 123]]
```

### レビュアー

@june29 さん、誰でも