### PR TITLE
ユーザー一覧を表示するアクションを作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ group :development, :test do
   gem 'pry-stack_explorer' 
   gem 'rubocop', require: false
   gem 'faker'
+  gem 'rack_session_access'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,6 +171,9 @@ GEM
     rack (2.0.5)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
+    rack_session_access (0.2.0)
+      builder (>= 2.0.0)
+      rack (>= 1.0.0)
     rails (5.2.1)
       actioncable (= 5.2.1)
       actionmailer (= 5.2.1)
@@ -307,6 +310,7 @@ DEPENDENCIES
   pry-rails
   pry-stack_explorer
   puma (~> 3.11)
+  rack_session_access
   rails (~> 5.2.1)
   rspec
   rspec-rails

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,22 @@
+class Admin::UsersController < ApplicationController
+  before_action :require_admin!, only: [:index, :new, :edit, :update, :destory]
+
+  def index
+    @users = User.all
+  end
+
+  def new
+  end
+
+  def create
+  end
+
+  def edit
+  end
+
+  def update
+  end
+
+  def destroy
+  end
+end

--- a/app/controllers/concerns/session.rb
+++ b/app/controllers/concerns/session.rb
@@ -17,6 +17,6 @@ module Session
 
   def require_admin!
     # TODO: ちゃんと 404 を返すものを作る
-    render file: "#{Rails.root}/public/404", status: :not_found unless @current_user.admin?
+    render file: "#{Rails.root}/public/404", status: :not_found unless logged_in? && @current_user.admin?
   end
 end

--- a/app/controllers/concerns/session.rb
+++ b/app/controllers/concerns/session.rb
@@ -14,4 +14,9 @@ module Session
   def require_logged_in!
     redirect_to login_path unless logged_in?
   end
+
+  def require_admin!
+    # TODO: ちゃんと 404 を返すものを作る
+    render file: "#{Rails.root}/public/404", status: :not_found unless @current_user.admin?
+  end
 end

--- a/app/controllers/concerns/session.rb
+++ b/app/controllers/concerns/session.rb
@@ -17,6 +17,6 @@ module Session
 
   def require_admin!
     # TODO: ちゃんと 404 を返すものを作る
-    render file: "#{Rails.root}/public/404", status: :not_found unless logged_in? && @current_user.admin?
+    render file: "#{Rails.root}/public/404", status: :not_found unless @current_user&.admin?
   end
 end

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,3 @@
+<% @users.each do | user | %>
+  <p><%= user.email %> <%= user.admin %></p>
+<% end %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -47,4 +47,8 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # セッションを自在に操作しやすいように
+  # https://github.com/railsware/rack_session_access
+  config.middleware.use RackSessionAccess::Middleware
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,12 @@
 Rails.application.routes.draw do
   root to: 'tasks#index'
-  # User Registration
+
+  # Admin
+  namespace :admin do
+    get 'users', to: 'users#index'
+  end
+
+  # Signup
   get 'signup', to: 'users#new'
   post 'signup', to: 'users#create'
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,10 +7,18 @@ require 'faker'
   )
 end
 
+3.times do |i|
+  User.create(
+    email: "admin#{i+1}@example.com",
+    password: 'Password1234',
+    admin: true
+  )
+end
+
 10.times do |i|
   created_at = Faker::Time.forward.to_datetime
   expire_at = created_at + 2.days
-  user_id = Faker::Number.between(0, 2)
+  user_id = Faker::Number.between(0, User.all.count)
   Task.create(
     title:    "タスク#{i+1} - user#{user_id}",
     description:  "内容#{i+1}",

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -50,5 +50,10 @@ FactoryBot.define do
     factory :invalid_email do
       email 'email.com'
     end
+
+    factory :admin do
+      email 'amdin@example.com'
+      admin true
+    end
   end
 end

--- a/spec/features/admin/user_spec.rb
+++ b/spec/features/admin/user_spec.rb
@@ -17,4 +17,9 @@ describe 'Admin' do
     visit admin_users_path
     expect(page).to have_http_status(404)
   end
+
+  example 'ログインしていないユーザーはユーザー一覧ページにアクセスできないこと' do
+    visit admin_users_path
+    expect(current_path).to eq(login_path)
+  end
 end

--- a/spec/features/admin/user_spec.rb
+++ b/spec/features/admin/user_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+require 'faker'
+
+describe 'Admin' do
+  let!(:admin) { create(:admin) }
+  let(:user) { create(:user1) }
+
+  example 'ユーザー一覧ページにアクセスできること' do
+    login_as admin
+    # page.set_rack_session(user_id: admin_user.id)
+    visit admin_users_path
+    expect(page).to have_http_status(200)
+  end
+
+  example '一般ユーザーはユーザー一覧ページにアクセスできないこと' do
+    login_as user
+    visit admin_users_path
+    expect(page).to have_http_status(404)
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
@@ -59,4 +59,6 @@ RSpec.configure do |config|
 
   # FactoryBot configure
   config.include FactoryBot::Syntax::Methods
+  # Use LoginHelper, Rack Session Access
+  config.include LoginHelper
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,8 @@
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+require "rack_session_access/capybara"
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest

--- a/spec/support/login_helper.rb
+++ b/spec/support/login_helper.rb
@@ -1,0 +1,5 @@
+module LoginHelper
+  def login_as(user)
+    page.set_rack_session(user_id: user.id)
+  end
+end


### PR DESCRIPTION
### 概要

`/admin/users` にアクセスするとユーザー一覧を表示するアクションを作成しました。  
Admin での作業は `admin/` 配下にまとめたほうがいいと思ったので、そこにまとめました。

以下の要件を満たします。

- [x] 管理画面にはかならず `/admin` というURLを先頭につけるようにしましょう
- [x] 管理ユーザだけがユーザ管理画面にアクセスできるようにしてみましょう

以下はこの後着手する予定なので、空の状態にしています。

- edit / update などの index 以外のアクション
- 404 をきちんと返すように routes に追加する

### レビュアー

@june29 さん、誰でも

### ref

https://github.com/everyleaf/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9721-%E3%83%A6%E3%83%BC%E3%82%B6%E3%81%AE%E7%AE%A1%E7%90%86%E7%94%BB%E9%9D%A2%E3%82%92%E5%AE%9F%E8%A3%85%E3%81%97%E3%82%88%E3%81%86