### PR TITLE
admin 専用ページでユーザー一覧を表示するようにした

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,8 @@ gem 'kaminari'
 gem 'bootstrap', '~> 4.1.3'
 gem 'jquery-rails'
 
+gem 'counter_culture', '~> 2.0'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,9 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    after_commit_action (1.1.0)
+      activerecord (>= 3.0.0)
+      activesupport (>= 3.0.0)
     archive-zip (0.11.0)
       io-like (~> 0.3.0)
     arel (9.0.0)
@@ -86,6 +89,10 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
+    counter_culture (2.0.1)
+      activerecord (>= 3.0.0)
+      activesupport (>= 3.0.0)
+      after_commit_action (~> 1.0)
     crass (1.0.4)
     debug_inspector (0.0.3)
     diff-lcs (1.3)
@@ -297,6 +304,7 @@ DEPENDENCIES
   capybara (>= 2.15, < 4.0)
   chromedriver-helper
   coffee-rails (~> 4.2)
+  counter_culture (~> 2.0)
   factory_bot_rails
   faker
   http_accept_language

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,5 +1,6 @@
 class Task < ApplicationRecord
   belongs_to :user
+  counter_culture :user
   enum status: { todo: 0, doing: 1, done: 2 }
   enum priority: { non: 0, low: 1, meddium: 2, high: 3 }
 

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,3 +1,27 @@
-<% @users.each do | user | %>
-  <p><%= user.email %> <%= user.admin %></p>
-<% end %>
+<table id="user_table" class="table">
+  <thead class="thead-dark">
+    <tr>
+      <th>Email</th>
+      <th>Task</th>
+      <th>Action</th>
+    </tr>
+  </thead>
+  <tbody id="user_table_body">
+    <% @users.each do | user | %>
+      <% if user.admin %>
+        <tr class="text-danger">
+      <% else %>
+        <tr>
+      <% end %>
+        <td id="email"><%= user.email %></td>
+        <td id="task">
+          <%= user.tasks_count %>
+        </td>
+        <td id="action">
+          <button class="btn">編集</button>
+          <button class="btn">削除</button>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/db/migrate/20180919061521_add_tasks_count_to_users.rb
+++ b/db/migrate/20180919061521_add_tasks_count_to_users.rb
@@ -1,0 +1,9 @@
+class AddTasksCountToUsers < ActiveRecord::Migration[5.2]
+  def self.up
+    add_column :users, :tasks_count, :integer, null: false, default: 0
+  end
+
+  def self.down
+    remove_column :users, :tasks_count
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_11_053552) do
+ActiveRecord::Schema.define(version: 2018_09_19_061521) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(version: 2018_09_11_053552) do
     t.boolean "admin", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "tasks_count", default: 0, null: false
   end
 
 end


### PR DESCRIPTION
### 概要

- `/admin/users` でユーザー一覧を表示するようにした
- ユーザーのタスク数を表示するようにした
  - タスク数の表示のために `counter-cache` を使用して `tasks_count` み保持するようにしている
- adminユーザーは分かりやすいように赤色で表示している
- ユーザーの編集・削除などはまだ作っていない

### その他

- 最初は `@users = User.all.includes(:tasks)` で `user.tasks.size` で表示しようとしていた
- しかし、この画面でユーザーのタスク一覧を表示する必要はなく、タスクを読み込むのが無駄だと思ったのでタスク数を保持するようにした

### レビュアー

@june29 さん、誰でも

### ref

- https://github.com/everyleaf/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9721-%E3%83%A6%E3%83%BC%E3%82%B6%E3%81%AE%E7%AE%A1%E7%90%86%E7%94%BB%E9%9D%A2%E3%82%92%E5%AE%9F%E8%A3%85%E3%81%97%E3%82%88%E3%81%86