### PR TITLE
Admin ページでユーザーを編集する機能を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,7 @@ group :test do
   gem 'rspec-rails'
   gem 'factory_bot_rails'
   gem 'bullet'
+  gem 'rails-controller-testing'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,6 +194,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.2.1)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.2)
+      actionpack (~> 5.x, >= 5.0.1)
+      actionview (~> 5.x, >= 5.0.1)
+      activesupport (~> 5.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -320,6 +324,7 @@ DEPENDENCIES
   puma (~> 3.11)
   rack_session_access
   rails (~> 5.2.1)
+  rails-controller-testing
   rspec
   rspec-rails
   rubocop

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,5 +1,6 @@
 class Admin::UsersController < ApplicationController
   before_action :require_admin!, only: [:index, :new, :edit, :update, :destory]
+  before_action :set_user, only: [:update]
 
   def index
     @users = User.all
@@ -15,8 +16,21 @@ class Admin::UsersController < ApplicationController
   end
 
   def update
+    if @user.update(user_params)
+      redirect_to admin_users_path, flash: { success: t('view.user.message.updated') }
+    end
   end
 
   def destroy
   end
+
+  private
+
+    def set_user
+      @user = User.find_by(id: params[:id])
+    end
+
+    def user_params
+      params.require(:user).permit(:email)
+    end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,5 +11,7 @@ class User < ApplicationRecord
     inclusion: { in: [true, false] }
   # パスワードは半角英小文字大文字数字が1種類以上含まれて8文字以上であること
   validates :password,
-    presence: true, length: { minimum: 8 }, format: {allow_blank: true, with: /\A(?=.*?[a-z])(?=.*?[A-Z])(?=.*?\d)[a-zA-Z\d]+\z/}
+    presence: true, length: { minimum: 8 }, format: {allow_blank: true, with: /\A(?=.*?[a-z])(?=.*?[A-Z])(?=.*?\d)[a-zA-Z\d]+\z/}, on: :create
+  validates :password,
+    presence: true, length: { minimum: 8 }, format: {allow_blank: true, with: /\A(?=.*?[a-z])(?=.*?[A-Z])(?=.*?\d)[a-zA-Z\d]+\z/}, on: :password_update
 end

--- a/app/views/admin/users/_user_edit_modal.erb
+++ b/app/views/admin/users/_user_edit_modal.erb
@@ -1,0 +1,25 @@
+<%# ユーザー編集モーダル %>
+  <div class="modal fade" id="user-<%= user.id %>-edit-modal" tabindex="-1" role="dialog" aria-labelledby="user-edit" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="exampleModalLongTitle">ユーザーの編集</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+      <%= form_with(model: user, method: :put, url: admin_user_edit_path(id: user.id)) do |form| %>
+        <div class="form-group">
+          <%= form.label :email %>
+          <%= form.text_field :email, class: "form-control", value: user.email %>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button id="submit" type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+        <%= form.submit id: "submit", class: "btn btn-primary" %>
+      </div>
+        <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -18,7 +18,10 @@
           <%= user.tasks_count %>
         </td>
         <td id="action">
-          <button class="btn">編集</button>
+        <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#user-<%= user.id %>-edit-modal">
+            編集
+          </button>
+          <%= render 'user_edit_modal', user: user %>
           <button class="btn">削除</button>
         </td>
       </tr>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,7 @@ en:
       message:
         registration_successful: "Registration is successful. Please Login."
         missmatch_password: "Missmatch password."
+        updated: "Updated"
     session:
       message:
         login_successful: "Login Successful"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,6 +5,7 @@ ja:
       message:
         registration_successful: "登録が完了しました。ログインしてください。"
         missmatch_password: "パスワードが一致していません"
+        updated: "更新しました"
     session:
       message:
         login_successful: "ログインしました"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   # Admin
   namespace :admin do
     get 'users', to: 'users#index'
+    put 'users/edit/:id', to: 'users#update', as: 'user_edit'
   end
 
   # Signup

--- a/spec/controller/admin/user_spec.rb
+++ b/spec/controller/admin/user_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+describe Admin::UsersController, :type => :controller do
+  describe 'GET admin/users#index' do
+    let(:admin) { create(:admin) }
+
+    before do
+      login admin
+      get :index
+    end
+
+    it '200が返ること' do
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'PUT admin/users#update' do
+    let(:admin) { create(:admin) }
+    let(:user) { create(:user1) }
+    let(:update_params) do
+      { email: 'weitarou@example.com' }
+    end
+    let(:invalid_params) do
+      { email: 'weitarou' }
+    end
+
+    before do
+      login admin
+    end
+
+    it 'アップデートできること' do
+      put :update, params: { id: user.id, user: update_params }
+      expect(User.where(email: 'weitarou@example.com').count).to eq(1)
+    end
+
+    it 'メールアドレスが不正な場合アップデートできないこと' do
+      put :update, params: { id: user.id, user: invalid_params }
+      expect(User.where(email: 'weitarou').count).to eq(0)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -27,6 +27,11 @@ Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
+  [:controller, :view, :request].each do |type|
+    config.include ::Rails::Controller::Testing::TestProcess, type: type
+    config.include ::Rails::Controller::Testing::TemplateAssertions, type: type
+    config.include ::Rails::Controller::Testing::Integration, type: type
+  end
   Capybara.javascript_driver = :webkit
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures

--- a/spec/support/login_helper.rb
+++ b/spec/support/login_helper.rb
@@ -2,4 +2,8 @@ module LoginHelper
   def login_as(user)
     page.set_rack_session(user_id: user.id)
   end
+
+  def login(user)
+    request.session[:user_id] = user.id
+  end
 end


### PR DESCRIPTION
###  概要

Admin のユーザー一覧ページからユーザー情報を編集する機能を作りました。

<img width="1147" alt="2018-10-01 19 01 42" src="https://user-images.githubusercontent.com/5842353/46282439-78691700-c5ac-11e8-95e7-bbfba74f33c4.png">

編集＞モーダル出現＞更新する でメールアドレスとロールが変更されます。

### レビューポイント

- `update` 時に Password Validation がかかるので、`on: create` を追加しました
  - 将来的にパスワード変更は追加されるので別途 `on: password_update` を追加していますが、このアクションはまだ作っていません。
  - ここのバリデーションを2つ書くことになって冗長なので、短くしたい...

### レビュアー

@june29 さん、誰でも